### PR TITLE
Refine unit command handling and flexible attack ranges

### DIFF
--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/CommandComponent.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/CommandComponent.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 #include "CoreMinimal.h"
 #include "Components/ActorComponent.h"
@@ -44,17 +44,33 @@ protected:
 // Commands
 #pragma region Command Functions
 private:
-	UFUNCTION()
-	void CommandPatrol(const FCommandData CommandData);
-	UFUNCTION()
-	void CommandMove(const FCommandData CommandData);
-	UFUNCTION()
-	void DestinationReached(const FCommandData CommandData);
+        UFUNCTION()
+        void CommandPatrol(const FCommandData CommandData);
+        UFUNCTION()
+        void CommandMove(const FCommandData CommandData);
+        UFUNCTION()
+        void DestinationReached(const FCommandData CommandData);
 
-	UFUNCTION()
-	void SetWalk() const;
-	UFUNCTION()
-	void SetRun() const;
+        UFUNCTION()
+        bool ShouldFollowCommandTarget(const FCommandData& CommandData) const;
+        UFUNCTION()
+        bool HasValidAttackTarget(const FCommandData& CommandData) const;
+        UFUNCTION()
+        FVector ResolveDestinationFromCommand(const FCommandData& CommandData) const;
+        UFUNCTION()
+        void ApplyMovementSettings(const FCommandData& CommandData);
+
+        void PrepareCommand(FCommandData& CommandData);
+        void BeginPatrol(const FCommandData& CommandData);
+        void BeginMove(const FCommandData& CommandData);
+        void UpdateTrackedTarget();
+        void UpdateMoveMarkerAttachment(const FCommandData& CommandData);
+        void ResetMoveMarkerAttachment();
+
+        UFUNCTION()
+        void SetWalk() const;
+        UFUNCTION()
+        void SetRun() const;
 	UFUNCTION()
 	void SetSprint() const;
 
@@ -82,10 +98,15 @@ private:
 	UPROPERTY(EditAnywhere)
 	TObjectPtr<AAiControllerRts> OwnerAIController;
 
-	UPROPERTY(EditAnywhere, Category = "Command|Settings")
-	float MaxSpeed = 100.f;
-	UPROPERTY()
-	FVector TargetLocation;
+        UPROPERTY(EditAnywhere, Category = "Command|Settings")
+        float MaxSpeed = 100.f;
+        UPROPERTY(EditAnywhere, Category = "Command|Settings")
+        float TargetUpdateTolerance = 25.f;
+
+        UPROPERTY(EditAnywhere, Category = "Command|Settings")
+        float OrientationInterpSpeed = 2.f;
+        UPROPERTY()
+        FVector TargetLocation;
 
 	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (AllowPrivateAccess = true), Category = "Command|Settings")
 	TSubclassOf<AActor> MoveMarkerClass;
@@ -97,19 +118,22 @@ private:
 	UPROPERTY()
 	uint8 ShouldOrientate;
 
-	UPROPERTY()
-	bool HaveTargetAttack;
+        UPROPERTY()
+        bool bTrackCommandTarget = false;
+
+        UPROPERTY()
+        bool bAttachMarkerToCommandTarget = false;
 	
 #pragma endregion
 
 #pragma region Move Marker
 public:
-	UFUNCTION(Client, Reliable)
-	void ShowMoveMarker(bool bIsSelected);
-	
+        UFUNCTION(Client, Reliable)
+        void ShowMoveMarker(bool bIsSelected);
+
 protected:
-	UFUNCTION()
-	void CreatMoveMarker();
+        UFUNCTION()
+        void CreateMoveMarker();
 
 	UFUNCTION(NetMulticast, Reliable)
 	void SetMoveMarker(const FVector Location, const FCommandData CommandData);

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/WeaponMaster.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/WeaponMaster.h
@@ -16,13 +16,16 @@ public:
 	UWeaponMaster();
 	virtual void BeginPlay() override;
 
-	UFUNCTION()
-	void AIShoot(AActor* Target);
+        UFUNCTION()
+        void AIShoot(AActor* Target);
 
-	UFUNCTION()
-	void SetAiOwner(ASoldierRts* NewOwner);
-	UFUNCTION(Server, Reliable)
-	void SetAiOwner_Server(ASoldierRts* NewOwner);
+        UFUNCTION()
+        void SetAiOwner(ASoldierRts* NewOwner);
+        UFUNCTION(Server, Reliable)
+        void SetAiOwner_Server(ASoldierRts* NewOwner);
+
+        UFUNCTION(BlueprintCallable, Category = "Weapon")
+        float GetWeaponRange() const { return WeaponRange; }
 
 protected:
 	/*- Function -*/

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Data/AiData.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Data/AiData.h
@@ -1,4 +1,6 @@
-﻿#pragma once
+#pragma once
+
+#include "CoreMinimal.h"
 #include "AiData.generated.h"
 
 
@@ -37,6 +39,74 @@ enum class ETeams : uint8
 	Droid	UMETA(DisplayName = "Droid Team"),
 	HiveMind	UMETA(DisplayName = "HiveMind Team")
 };
+
+UENUM(BlueprintType)
+enum class EAttackType : uint8
+{
+	Melee	UMETA(DisplayName = "Melee"),
+	Ranged	UMETA(DisplayName = "Ranged")
+};
+
+USTRUCT(BlueprintType)
+struct FAttackSettings
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0"))
+	float MinRange = 0.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0"))
+	float PreferredRange = 150.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0"))
+	float MaxRange = 200.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0"))
+	float ChaseDistance = 400.f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0"))
+	float Cooldown = 1.5f;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack")
+	EAttackType AttackType = EAttackType::Melee;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack")
+	bool bUseWeaponRange = true;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Attack", meta = (ClampMin = "0.0", EditCondition = "bUseWeaponRange"))
+	float WeaponRangePadding = 50.f;
+
+	float ResolveMaxRange(const float WeaponRange) const
+	{
+		const bool bHasWeaponRange = bUseWeaponRange && WeaponRange > 0.f;
+		const float EffectiveMaxRange = bHasWeaponRange ? FMath::Max(WeaponRange - WeaponRangePadding, 0.f) : MaxRange;
+		return FMath::Max(EffectiveMaxRange, PreferredRange);
+	}
+
+	float ResolvePreferredRange(const float WeaponRange) const
+	{
+		const float ClampedMax = ResolveMaxRange(WeaponRange);
+		return FMath::Clamp(PreferredRange, MinRange, ClampedMax);
+	}
+
+	float ResolveMinRange(const float WeaponRange) const
+	{
+		const float ClampedMax = ResolveMaxRange(WeaponRange);
+		return FMath::Clamp(MinRange, 0.f, ClampedMax);
+	}
+
+	float ResolveChaseDistance(const float WeaponRange) const
+	{
+		const float EffectiveMax = ResolveMaxRange(WeaponRange);
+		return FMath::Max(ChaseDistance, EffectiveMax);
+	}
+
+	float ResolveCooldown() const
+	{
+		return FMath::Max(Cooldown, 0.f);
+	}
+};
+
 
 USTRUCT(BlueprintType)
 struct FCommandData

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/AI/AiControllerRts.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/AI/AiControllerRts.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "CoreMinimal.h"
 #include "AIController.h"
 #include "Data/AiData.h"
@@ -70,36 +70,41 @@ public:
 	void SetupVariables();
 
 protected:
-	/** AI settings */
-	UPROPERTY(EditAnywhere, Category="AI")
-	float MeleeApproachFactor = 0.3f;
+        /** AI settings */
+        UPROPERTY(EditAnywhere, Category="AI")
+        float DistanceTolerance = 25.f;
 
-	UPROPERTY(EditAnywhere, Category="AI")
-	float RangedStopDistance = 200.f;
-
-	UPROPERTY(EditAnywhere, Category="AI")
-	float AttackCooldown = 1.f;
+        UPROPERTY(EditAnywhere, Category="AI")
+        float RetreatBuffer = 100.f;
 
 private:
-	// Variables
-	UPROPERTY() ASoldierRts*       Soldier = nullptr;
-	UPROPERTY() FCommandData       CurrentCommand;
-	
-	UPROPERTY() bool               bMoveComplete = true;
-	UPROPERTY() bool               bPatrolling = false;
-	
-	UPROPERTY() bool               bAttackTarget = false;
-	UPROPERTY() bool               bCanAttack = true;
-	UPROPERTY() FTimerHandle       AttackTimer;
-	UPROPERTY() ECombatBehavior    CombatBehavior;
-	
-	// Functions
-	UFUNCTION() float GetAcceptanceRadius() const;
-	UFUNCTION() bool  ShouldApproach() const;
+        // Variables
+        UPROPERTY() ASoldierRts*       Soldier = nullptr;
+        UPROPERTY() FCommandData       CurrentCommand;
 
-	UFUNCTION() float GetDistanceToTarget() const;
-	UFUNCTION() bool  ShouldAttack() const;
-	UFUNCTION() void  PerformAttack();
-	
-	UFUNCTION() void  StartPatrol();
+        UPROPERTY() bool               bMoveComplete = true;
+        UPROPERTY() bool               bPatrolling = false;
+
+        UPROPERTY() bool               bAttackTarget = false;
+        UPROPERTY() bool               bCanAttack = true;
+        UPROPERTY() FTimerHandle       AttackTimer;
+        UPROPERTY() ECombatBehavior    CombatBehavior;
+
+        // Functions
+        UFUNCTION() float GetAcceptanceRadius() const;
+        UFUNCTION() bool  ShouldApproach() const;
+        UFUNCTION() bool  ShouldRetreat() const;
+
+        UFUNCTION() float GetDistanceToTarget() const;
+        UFUNCTION() bool  ShouldAttack() const;
+        UFUNCTION() void  PerformAttack();
+        UFUNCTION() void  MaintainDistance();
+
+        bool             IsOutsideLeashRange() const;
+
+        bool             HasValidAttackCommand() const;
+        bool             ValidateAttackCommand(const FCommandData& Cmd) const;
+        void             HandleInvalidAttackTarget();
+
+        UFUNCTION() void  StartPatrol();
 };

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/SoldierRts.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/SoldierRts.h
@@ -141,11 +141,23 @@ public:
 	virtual bool GetCanAttack_Implementation() override;
 	
 	/*- Getter -*/
-	UFUNCTION()
-	float GetAttackRange() const;
+        UFUNCTION()
+        float GetAttackRange() const;
 
-	UFUNCTION()
-	float GetAttackCooldown() const;
+        UFUNCTION()
+        float GetAttackCooldown() const;
+
+        UFUNCTION(BlueprintCallable, BlueprintPure)
+        float GetMinAttackDistance() const;
+
+        UFUNCTION(BlueprintCallable, BlueprintPure)
+        float GetPreferredAttackDistance() const;
+
+        UFUNCTION(BlueprintCallable, BlueprintPure)
+        float GetAttackChaseDistance() const;
+
+        UFUNCTION(BlueprintCallable, BlueprintPure)
+        const FAttackSettings& GetAttackSettings() const { return AttackSettings; }
 
 	UFUNCTION()
 	ECombatBehavior GetCombatBehavior() const;
@@ -169,28 +181,36 @@ protected:
 	UFUNCTION()
 	virtual void OnStartAttack(AActor* Target);
 
-	UFUNCTION()
-	void UpdateActorsInArea();
+        UFUNCTION()
+        void UpdateActorsInArea();
 
-	UFUNCTION()
-	void OnRep_CombatBehavior();
+        UFUNCTION()
+        void OnRep_CombatBehavior();
 
-	
-	/*- Variables -*/
-	UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (AllowPrivateAccess = true))
-	TObjectPtr<USphereComponent> AreaAttack;
+private:
+        bool IsValidSelectableActor(const AActor* Actor) const;
+        bool IsFriendlyActor(const AActor* Actor) const;
+        bool IsEnemyActor(const AActor* Actor) const;
+        bool ShouldAutoEngage() const;
+        FCommandData MakeAttackCommand(AActor* Target) const;
+        void IssueAttackOrder(const FCommandData& CommandData);
+        void HandleAutoEngage(AActor* Target);
+        void HandleTargetRemoval(AActor* OtherActor);
+        void NotifyAlliesOfThreat(AActor* Threat, const FCommandData& CommandData);
 
-	UPROPERTY(EditAnywhere, Category = "Settings|Attack")
-	bool bCanAttack = true;
-	
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings|Attack", ReplicatedUsing = OnRep_CombatBehavior)
-	ECombatBehavior CombatBehavior = ECombatBehavior::Passive;
 
-	UPROPERTY(EditAnywhere, Category = "Settings|Attack")
-	float AttackCooldown = 1.5f;
+        /*- Variables -*/
+        UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (AllowPrivateAccess = true))
+        TObjectPtr<USphereComponent> AreaAttack;
 
-	UPROPERTY(EditAnywhere, Category = "Settings|Attack")
-	float AttackRange = 200.f;
+        UPROPERTY(EditAnywhere, Category = "Settings|Attack")
+        bool bCanAttack = true;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings|Attack", ReplicatedUsing = OnRep_CombatBehavior)
+        ECombatBehavior CombatBehavior = ECombatBehavior::Passive;
+
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Settings|Attack")
+        FAttackSettings AttackSettings;
 	
 	UPROPERTY()
 	TArray<AActor*> ActorsInRange;


### PR DESCRIPTION
## Summary
- add configurable attack settings with min/preferred/chase distances and integrate soldier getters
- overhaul the command component to track dynamic attack targets and manage move markers from shared helpers
- extend the AI controller attack loop with retreat/leash logic and weapon-aware range checks for melee and ranged units
- expose weapon range accessors so firearms can drive engagement distances

## Testing
- not run (Unreal project build/test pipeline not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68ce690fd6208330ad20bc67d16e1bfe