### PR TITLE
Restore HUD display and selection outlines

### DIFF
--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Components/UnitSelectionComponent.cpp
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Components/UnitSelectionComponent.cpp
@@ -6,6 +6,7 @@
 #include "Interfaces/Selectable.h"
 #include "Kismet/GameplayStatics.h"
 #include "Net/UnrealNetwork.h"
+#include "UObject/ConstructorHelpers.h"
 #include "Widget/JupiterHudWidget.h"
 
 namespace
@@ -48,6 +49,12 @@ UUnitSelectionComponent::UUnitSelectionComponent()
 {
     PrimaryComponentTick.bCanEverTick = false;
     SetIsReplicatedByDefault(true);
+
+    static ConstructorHelpers::FClassFinder<UJupiterHudWidget> DefaultHudClass(TEXT("/JupiterPlugin/BP/Widgets/WB_Hud"));
+    if (DefaultHudClass.Succeeded())
+    {
+        HudClass = DefaultHudClass.Class;
+    }
 }
 
 void UUnitSelectionComponent::BeginPlay()
@@ -191,6 +198,20 @@ void UUnitSelectionComponent::CreateHud()
     if (HudInstance)
     {
         HudInstance->AddToViewport();
+
+        APawn* OwnerPawn = Cast<APawn>(GetOwner());
+        if (!OwnerPawn)
+        {
+            if (APlayerController* PC = ResolveOwnerController())
+            {
+                OwnerPawn = PC->GetPawn();
+            }
+        }
+
+        if (OwnerPawn)
+        {
+            HudInstance->InitializedJupiterHud(OwnerPawn);
+        }
     }
 }
 

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Units/SoldierRts.cpp
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Units/SoldierRts.cpp
@@ -163,16 +163,17 @@ void ASoldierRts::Deselect()
 
 void ASoldierRts::Highlight(const bool Highlight)
 {
-	TArray<UPrimitiveComponent*> Components;
-	GetComponents<UPrimitiveComponent>(Components);
-	
-	for (UPrimitiveComponent* VisualComp : Components)
-	{
-		if (UPrimitiveComponent* Prim = Cast<UPrimitiveComponent>(VisualComp))
-		{
-			Prim->SetRenderCustomDepth(Highlight);
-		}
-	}
+        TArray<UPrimitiveComponent*> Components;
+        GetComponents<UPrimitiveComponent>(Components);
+
+        for (UPrimitiveComponent* VisualComp : Components)
+        {
+                if (UPrimitiveComponent* Prim = Cast<UPrimitiveComponent>(VisualComp))
+                {
+                        Prim->SetRenderCustomDepth(Highlight);
+                        Prim->SetCustomDepthStencilValue(Highlight ? SelectionStencilValue : 0);
+                }
+        }
 }
 
 bool ASoldierRts::GetIsSelected_Implementation()

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Widget/JupiterHudWidget.cpp
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Widget/JupiterHudWidget.cpp
@@ -38,10 +38,10 @@ void UJupiterHudWidget::SetBehaviorSelectionWidget(const bool bEnabled) const
 
 void UJupiterHudWidget::SetUnitsSelectionWidget(bool bEnabled) const
 {
-	if (UnitsSelector)
-	{
-		BehaviorSelector->SetVisibility(bEnabled ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
-	}
+        if (UnitsSelector)
+        {
+                UnitsSelector->SetVisibility(bEnabled ? ESlateVisibility::Visible : ESlateVisibility::Collapsed);
+        }
 }
 
 void UJupiterHudWidget::InitializedJupiterHud(APawn* PawnLinked)
@@ -56,10 +56,11 @@ void UJupiterHudWidget::InitializedJupiterHud(APawn* PawnLinked)
 	SetUnitsSelectionWidget(true);
 
 
-	if (SelectionComponent)
-	{
-		SelectionComponent->OnSelectedUpdate.AddDynamic(this, &UJupiterHudWidget::OnSelectionUpdated);
-	}
+        if (SelectionComponent)
+        {
+                SelectionComponent->OnSelectedUpdate.AddUniqueDynamic(this, &UJupiterHudWidget::OnSelectionUpdated);
+                OnSelectionUpdated();
+        }
 }
 
 void UJupiterHudWidget::OnSelectionUpdated()

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/SoldierRts.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Units/SoldierRts.h
@@ -111,12 +111,16 @@ public:
 	FSelectedDelegate OnSelected;
 	
 protected:
-	/*- Variables -*/
-	UPROPERTY()
-	bool Selected;
-	
-	UPROPERTY()
-	TObjectPtr<APlayerControllerRts> PlayerOwner;
+        /*- Variables -*/
+        UPROPERTY()
+        bool Selected;
+
+        UPROPERTY()
+        TObjectPtr<APlayerControllerRts> PlayerOwner;
+
+        /** Custom depth stencil value applied when the unit is highlighted. */
+        UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Selection", meta = (ClampMin = "0", ClampMax = "255"))
+        int32 SelectionStencilValue = 1;
 
 #pragma endregion
 


### PR DESCRIPTION
## Summary
- load the default HUD widget from the plugin content and reinitialize it with the owning pawn
- ensure the unit selection UI toggles the correct panel and avoid duplicate delegate bindings
- apply a configurable custom depth stencil when highlighting units so outlines render reliably

## Testing
- not run (Unreal build tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cea02f516c8330890363389c7457ac