### PR TITLE
Add centralized RTS soldier manager component

### DIFF
--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Components/SoldierManagerComponent.cpp
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Private/Components/SoldierManagerComponent.cpp
@@ -1,0 +1,308 @@
+#include "Components/SoldierManagerComponent.h"
+
+#include "DrawDebugHelpers.h"
+#include "Components/ActorComponent.h"
+#include "Engine/Engine.h"
+#include "Engine/World.h"
+#include "EngineUtils.h"
+#include "GameFramework/PlayerController.h"
+#include "GameFramework/Pawn.h"
+#include "JupiterPlugin/Public/Units/SoldierRts.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogSoldierManager, Log, All);
+
+USoldierManagerComponent::USoldierManagerComponent()
+{
+        PrimaryComponentTick.bCanEverTick = true;
+        PrimaryComponentTick.bStartWithTickEnabled = true;
+        PrimaryComponentTick.TickInterval = 0.0f;
+}
+
+void USoldierManagerComponent::BeginPlay()
+{
+        Super::BeginPlay();
+
+        ManagedSoldiers.Reset();
+        SoldierAccumulatedTime.Reset();
+        RegisterExistingSoldiers();
+}
+
+void USoldierManagerComponent::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+        Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+        if (bRequiresCompaction)
+        {
+                CompactSoldierList();
+        }
+
+        for (float& PendingTime : SoldierAccumulatedTime)
+        {
+                PendingTime += DeltaTime;
+        }
+
+        if (HasAuthoritativeOwner())
+        {
+                ProcessSoldierBatch();
+        }
+
+        HandleDebugOutput(DeltaTime);
+}
+
+void USoldierManagerComponent::RegisterSoldier(ASoldierRts* Soldier)
+{
+        if (!IsValid(Soldier))
+        {
+                return;
+        }
+
+        if (bRequiresCompaction)
+        {
+                CompactSoldierList();
+        }
+
+        const int32 ExistingIndex = ManagedSoldiers.IndexOfByPredicate([Soldier](const TWeakObjectPtr<ASoldierRts>& Entry)
+        {
+                return Entry.Get() == Soldier;
+        });
+
+        if (ExistingIndex != INDEX_NONE)
+        {
+                SoldierAccumulatedTime[ExistingIndex] = 0.0f;
+                Soldier->OnSoldierManagerRegistered(this);
+                return;
+        }
+
+        ManagedSoldiers.Add(Soldier);
+        SoldierAccumulatedTime.Add(0.0f);
+        Soldier->OnSoldierManagerRegistered(this);
+}
+
+void USoldierManagerComponent::UnregisterSoldier(ASoldierRts* Soldier)
+{
+        if (!Soldier)
+        {
+                return;
+        }
+
+        const int32 ExistingIndex = ManagedSoldiers.IndexOfByPredicate([Soldier](const TWeakObjectPtr<ASoldierRts>& Entry)
+        {
+                return Entry.Get() == Soldier;
+        });
+
+        if (ExistingIndex != INDEX_NONE)
+        {
+                ManagedSoldiers[ExistingIndex] = nullptr;
+                SoldierAccumulatedTime[ExistingIndex] = 0.0f;
+                Soldier->OnSoldierManagerUnregistered(this);
+                bRequiresCompaction = true;
+        }
+}
+
+USoldierManagerComponent* USoldierManagerComponent::GetSoldierManagerFromPlayer(const APlayerController* PlayerController)
+{
+        if (!PlayerController)
+        {
+                return nullptr;
+        }
+
+        return PlayerController->FindComponentByClass<USoldierManagerComponent>();
+}
+
+USoldierManagerComponent* USoldierManagerComponent::GetSoldierManager(const UObject* WorldContextObject)
+{
+        if (!WorldContextObject)
+        {
+                return nullptr;
+        }
+
+        if (const UActorComponent* Component = Cast<UActorComponent>(WorldContextObject))
+        {
+                if (const AActor* Owner = Component->GetOwner())
+                {
+                        return GetSoldierManager(Owner);
+                }
+        }
+
+        if (const APlayerController* PlayerController = Cast<APlayerController>(WorldContextObject))
+        {
+                return GetSoldierManagerFromPlayer(PlayerController);
+        }
+
+        if (const APawn* Pawn = Cast<APawn>(WorldContextObject))
+        {
+                if (USoldierManagerComponent* ManagerFromPawn = Pawn->FindComponentByClass<USoldierManagerComponent>())
+                {
+                        return ManagerFromPawn;
+                }
+
+                if (const APlayerController* OwningController = Cast<APlayerController>(Pawn->GetController()))
+                {
+                        if (USoldierManagerComponent* Manager = GetSoldierManagerFromPlayer(OwningController))
+                        {
+                                return Manager;
+                        }
+                }
+        }
+
+        if (const AActor* Actor = Cast<AActor>(WorldContextObject))
+        {
+                if (USoldierManagerComponent* ManagerFromActor = Actor->FindComponentByClass<USoldierManagerComponent>())
+                {
+                        return ManagerFromActor;
+                }
+
+                if (const APawn* OwningPawn = Cast<APawn>(Actor))
+                {
+                        if (const APlayerController* OwningController = Cast<APlayerController>(OwningPawn->GetController()))
+                        {
+                                if (USoldierManagerComponent* Manager = GetSoldierManagerFromPlayer(OwningController))
+                                {
+                                        return Manager;
+                                }
+                        }
+                }
+        }
+
+        UWorld* World = GEngine ? GEngine->GetWorldFromContextObject(WorldContextObject, EGetWorldErrorMode::LogAndReturnNull) : nullptr;
+        if (!World)
+        {
+                return nullptr;
+        }
+
+        for (FConstPlayerControllerIterator It = World->GetPlayerControllerIterator(); It; ++It)
+        {
+                if (const APlayerController* PlayerController = It->Get())
+                {
+                        if (USoldierManagerComponent* Manager = GetSoldierManagerFromPlayer(PlayerController))
+                        {
+                                return Manager;
+                        }
+                }
+        }
+
+        return nullptr;
+}
+
+void USoldierManagerComponent::RegisterExistingSoldiers()
+{
+        UWorld* World = GetWorld();
+        if (!World)
+        {
+                return;
+        }
+
+        for (TActorIterator<ASoldierRts> It(World); It; ++It)
+        {
+                RegisterSoldier(*It);
+        }
+}
+
+void USoldierManagerComponent::CompactSoldierList()
+{
+        for (int32 Index = ManagedSoldiers.Num() - 1; Index >= 0; --Index)
+        {
+                if (!ManagedSoldiers[Index].IsValid())
+                {
+                        ManagedSoldiers.RemoveAtSwap(Index, 1, false);
+                        SoldierAccumulatedTime.RemoveAtSwap(Index, 1, false);
+                }
+        }
+
+        if (ManagedSoldiers.Num() == 0)
+        {
+                CurrentGroupIndex = 0;
+        }
+
+        bRequiresCompaction = false;
+}
+
+bool USoldierManagerComponent::HasAuthoritativeOwner() const
+{
+        const AActor* OwnerActor = GetOwner();
+        return OwnerActor == nullptr || OwnerActor->HasAuthority();
+}
+
+void USoldierManagerComponent::ProcessSoldierBatch()
+{
+        const int32 SoldierCount = ManagedSoldiers.Num();
+        if (SoldierCount == 0)
+        {
+                CurrentGroupIndex = 0;
+                return;
+        }
+
+        const int32 GroupCount = FMath::Max(UpdateGroupCount, 1);
+        const int32 SoldiersPerGroup = FMath::CeilToInt(static_cast<float>(SoldierCount) / static_cast<float>(GroupCount));
+        int32 StartIndex = SoldiersPerGroup * CurrentGroupIndex;
+        if (StartIndex >= SoldierCount)
+        {
+                CurrentGroupIndex = 0;
+                StartIndex = 0;
+        }
+
+        const int32 EndIndex = FMath::Min(StartIndex + SoldiersPerGroup, SoldierCount);
+
+        for (int32 Index = StartIndex; Index < EndIndex && Index < ManagedSoldiers.Num(); ++Index)
+        {
+                ASoldierRts* Soldier = ManagedSoldiers[Index].Get();
+                if (!IsValid(Soldier))
+                {
+                        SoldierAccumulatedTime[Index] = 0.0f;
+                        bRequiresCompaction = true;
+                        continue;
+                }
+
+                const float AccumulatedDelta = SoldierAccumulatedTime[Index];
+                if (AccumulatedDelta > 0.0f)
+                {
+                        Soldier->UpdateAttackDetection(AccumulatedDelta);
+                }
+
+                SoldierAccumulatedTime[Index] = 0.0f;
+
+                if (bDrawDebugForUpdatedSoldiers)
+                {
+                        DrawDebugForSoldier(Soldier);
+                }
+        }
+
+        CurrentGroupIndex = (CurrentGroupIndex + 1) % FMath::Max(GroupCount, 1);
+}
+
+void USoldierManagerComponent::DrawDebugForSoldier(ASoldierRts* Soldier) const
+{
+        if (!Soldier || !GetWorld())
+        {
+                return;
+        }
+
+        const FColor DebugColor = DebugSphereColor.ToFColor(true);
+        DrawDebugSphere(GetWorld(), Soldier->GetActorLocation(), DebugSphereRadius, 12, DebugColor, false, 0.1f);
+}
+
+void USoldierManagerComponent::HandleDebugOutput(float DeltaTime)
+{
+        if (!bLogManagedSoldierCount)
+        {
+                return;
+        }
+
+        TimeSinceLastDebugLog += DeltaTime;
+        if (TimeSinceLastDebugLog < DebugLogInterval)
+        {
+                return;
+        }
+
+        TimeSinceLastDebugLog = 0.0f;
+
+        const int32 SoldierCount = ManagedSoldiers.Num();
+        UE_LOG(LogSoldierManager, Log, TEXT("SoldierManager managing %d soldiers"), SoldierCount);
+
+        if (GEngine)
+        {
+                const uint64 DebugMessageKey = reinterpret_cast<uint64>(this);
+                const FString DebugText = FString::Printf(TEXT("Managed Soldiers: %d"), SoldierCount);
+                GEngine->AddOnScreenDebugMessage(DebugMessageKey, DebugLogInterval, FColor::Yellow, DebugText);
+        }
+}

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/SoldierManagerComponent.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/SoldierManagerComponent.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "SoldierManagerComponent.generated.h"
+
+class ASoldierRts;
+class APlayerController;
+
+/**
+ * Centralized manager responsible for distributing expensive RTS soldier updates.
+ */
+UCLASS(ClassGroup = (Custom), Blueprintable, meta = (BlueprintSpawnableComponent))
+class JUPITERPLUGIN_API USoldierManagerComponent : public UActorComponent
+{
+        GENERATED_BODY()
+
+public:
+        USoldierManagerComponent();
+
+        virtual void BeginPlay() override;
+        virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+        /** Registers a soldier with the manager so it can receive distributed updates. */
+        UFUNCTION(BlueprintCallable, Category = "Soldiers")
+        void RegisterSoldier(ASoldierRts* Soldier);
+
+        /** Removes a soldier from the manager. */
+        UFUNCTION(BlueprintCallable, Category = "Soldiers")
+        void UnregisterSoldier(ASoldierRts* Soldier);
+
+        /** Returns all currently registered soldiers. */
+        const TArray<TWeakObjectPtr<ASoldierRts>>& GetAllSoldiers() const { return ManagedSoldiers; }
+
+        /** Returns the manager associated with the provided player controller, if any. */
+        UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Soldiers")
+        static USoldierManagerComponent* GetSoldierManagerFromPlayer(const APlayerController* PlayerController);
+
+        /** Finds a soldier manager using the provided world context (player controller, pawn, world, ...). */
+        UFUNCTION(BlueprintCallable, BlueprintPure, Category = "Soldiers", meta = (WorldContext = "WorldContextObject"))
+        static USoldierManagerComponent* GetSoldierManager(const UObject* WorldContextObject);
+
+protected:
+        /** Populates the manager with any soldiers that already exist in the world. */
+        void RegisterExistingSoldiers();
+
+        /** Removes invalid soldier references from the list. */
+        void CompactSoldierList();
+
+        /** Returns true when the component is allowed to run authoritative logic. */
+        bool HasAuthoritativeOwner() const;
+
+        /** Processes the next batch of soldiers scheduled for this frame. */
+        void ProcessSoldierBatch();
+
+        /** Draws optional debug helpers for the supplied soldier. */
+        void DrawDebugForSoldier(ASoldierRts* Soldier) const;
+
+        /** Optionally prints debug information. */
+        void HandleDebugOutput(float DeltaTime);
+
+protected:
+        /** How many batches the manager divides the soldiers into. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Update", meta = (ClampMin = "1"))
+        int32 UpdateGroupCount = 5;
+
+        /** Enables drawing debug spheres for the soldiers that were updated during this frame. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug")
+        bool bDrawDebugForUpdatedSoldiers = false;
+
+        /** Enables regular debug logging for the number of managed soldiers. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug")
+        bool bLogManagedSoldierCount = false;
+
+        /** Duration between debug log entries when logging is enabled. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug", meta = (ClampMin = "0.1"))
+        float DebugLogInterval = 2.0f;
+
+        /** Radius of the debug spheres used to visualize updated soldiers. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug", meta = (ClampMin = "0.0"))
+        float DebugSphereRadius = 25.0f;
+
+        /** Color used for debug drawing. */
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug")
+        FLinearColor DebugSphereColor = FLinearColor::Blue;
+
+private:
+        /** Array of managed soldiers. */
+        TArray<TWeakObjectPtr<ASoldierRts>> ManagedSoldiers;
+
+        /** Accumulated delta seconds for each managed soldier. */
+        TArray<float> SoldierAccumulatedTime;
+
+        /** Current update batch index. */
+        int32 CurrentGroupIndex = 0;
+
+        /** Time since the last debug log entry. */
+        float TimeSinceLastDebugLog = 0.0f;
+
+        /** Tracks whether the soldier list contains stale entries that require compaction. */
+        bool bRequiresCompaction = false;
+};


### PR DESCRIPTION
## Summary
- add a SoldierManager actor component that discovers, tracks, and batch-updates RTS soldiers while offering debug utilities
- update ASoldierRts to register with the manager, defer detection ticks to batches, and cleanly unregister on shutdown

## Testing
- not run (Unreal build/tests not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d119fd7e348330b86d4118d417ab6d