### PR TITLE
Add DynamicPathfindingPlugin with voxel flow-field navigation

### DIFF
--- a/Plugins/DynamicPathfindingPlugin/DynamicPathfindingPlugin.uplugin
+++ b/Plugins/DynamicPathfindingPlugin/DynamicPathfindingPlugin.uplugin
@@ -1,0 +1,19 @@
+{
+    "FileVersion": 3,
+    "Version": 1,
+    "VersionName": "1.0.0",
+    "FriendlyName": "Dynamic Pathfinding Plugin",
+    "Description": "Scalable dynamic voxel-based pathfinding and avoidance for large unit counts.",
+    "Category": "AI",
+    "CreatedBy": "OpenAI Assistant",
+    "Modules": [
+        {
+            "Name": "DynamicPathfindingRuntime",
+            "Type": "Runtime",
+            "LoadingPhase": "Default"
+        }
+    ],
+    "CanContainContent": false,
+    "IsBetaVersion": true,
+    "SupportURL": "https://example.com"
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/DynamicPathfindingRuntime.Build.cs
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/DynamicPathfindingRuntime.Build.cs
@@ -1,0 +1,27 @@
+using UnrealBuildTool;
+
+public class DynamicPathfindingRuntime : ModuleRules
+{
+    public DynamicPathfindingRuntime(ReadOnlyTargetRules Target) : base(Target)
+    {
+        PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
+
+        PublicDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Core",
+                "CoreUObject",
+                "Engine",
+                "InputCore",
+                "AIModule",
+                "NavigationSystem"
+            });
+
+        PrivateDependencyModuleNames.AddRange(
+            new string[]
+            {
+                "Projects",
+                "GameplayTasks"
+            });
+    }
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/DynamicPathManager.cpp
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/DynamicPathManager.cpp
@@ -1,0 +1,299 @@
+#include "DynamicPathManager.h"
+#include "GridNavigationComponent.h"
+#include "UnitNavigationComponent.h"
+#include "UnitAvoidanceComponent.h"
+#include "DrawDebugHelpers.h"
+#include "EngineUtils.h"
+
+ADynamicPathManager::ADynamicPathManager()
+{
+    PrimaryActorTick.bCanEverTick = true;
+    PrimaryActorTick.TickInterval = 0.016f;
+
+    GridComponent = CreateDefaultSubobject<UGridNavigationComponent>(TEXT("GridNavigation"));
+
+    SpatialHashCellSize = 300.f;
+    bDrawAvoidanceDebug = false;
+}
+
+void ADynamicPathManager::BeginPlay()
+{
+    Super::BeginPlay();
+}
+
+void ADynamicPathManager::PostRegisterAllComponents()
+{
+    Super::PostRegisterAllComponents();
+
+    if (GridComponent)
+    {
+        GridComponent->RegisterComponent();
+    }
+}
+
+void ADynamicPathManager::Tick(float DeltaSeconds)
+{
+    Super::Tick(DeltaSeconds);
+
+    if (GridComponent)
+    {
+        GridComponent->DrawDebug();
+    }
+
+    if (bDrawAvoidanceDebug)
+    {
+        DrawAvoidanceDebug();
+    }
+}
+
+void ADynamicPathManager::SetDebugEnabled(bool bEnabled)
+{
+    if (GridComponent)
+    {
+        GridComponent->SetDebugEnabled(bEnabled);
+    }
+
+    bDrawAvoidanceDebug = bEnabled;
+}
+
+void ADynamicPathManager::SetTargetLocation(const FVector& TargetLocation)
+{
+    if (GridComponent)
+    {
+        GridComponent->SetTargetLocation(TargetLocation);
+    }
+}
+
+void ADynamicPathManager::ToggleDynamicPathDebug()
+{
+    const bool bNewEnabled = !bDrawAvoidanceDebug;
+    SetDebugEnabled(bNewEnabled);
+}
+
+void ADynamicPathManager::RegisterUnit(UUnitNavigationComponent* UnitComponent)
+{
+    if (!UnitComponent)
+    {
+        return;
+    }
+
+    RegisteredUnits.Add(UnitComponent);
+}
+
+void ADynamicPathManager::UnregisterUnit(UUnitNavigationComponent* UnitComponent)
+{
+    if (!UnitComponent)
+    {
+        return;
+    }
+
+    RegisteredUnits.Remove(UnitComponent);
+}
+
+void ADynamicPathManager::RegisterAvoidanceComponent(UUnitAvoidanceComponent* Component)
+{
+    if (!Component)
+    {
+        return;
+    }
+
+    Component->SetManager(this);
+    const FVector Location = Component->GetOwner() ? Component->GetOwner()->GetActorLocation() : GetActorLocation();
+    const FIntVector CellKey = GetCellKey(Location);
+    Component->UpdateSpatialCellKey(CellKey);
+
+    FSpatialCell& Cell = SpatialHash.FindOrAdd(CellKey);
+    if (!Cell.Components.Contains(Component))
+    {
+        Cell.Components.Add(Component);
+    }
+}
+
+void ADynamicPathManager::UnregisterAvoidanceComponent(UUnitAvoidanceComponent* Component)
+{
+    if (!Component)
+    {
+        return;
+    }
+
+    const FIntVector CellKey = Component->GetSpatialCellKey();
+    RemoveComponentFromCell(Component, CellKey);
+}
+
+void ADynamicPathManager::UpdateSpatialEntry(UUnitAvoidanceComponent* Component, const FVector& Location)
+{
+    if (!Component)
+    {
+        return;
+    }
+
+    const FIntVector NewKey = GetCellKey(Location);
+    const FIntVector OldKey = Component->GetSpatialCellKey();
+
+    if (NewKey != OldKey)
+    {
+        RemoveComponentFromCell(Component, OldKey);
+        FSpatialCell& NewCell = SpatialHash.FindOrAdd(NewKey);
+        NewCell.Components.Add(Component);
+        Component->UpdateSpatialCellKey(NewKey);
+    }
+    else
+    {
+        FSpatialCell& Cell = SpatialHash.FindOrAdd(NewKey);
+        if (!Cell.Components.Contains(Component))
+        {
+            Cell.Components.Add(Component);
+        }
+    }
+}
+
+FVector ADynamicPathManager::ComputeAvoidanceForComponent(const UUnitAvoidanceComponent* Component, const FVector& DesiredVelocity) const
+{
+    if (!Component)
+    {
+        return FVector::ZeroVector;
+    }
+
+    const FVector Location = Component->GetOwner() ? Component->GetOwner()->GetActorLocation() : FVector::ZeroVector;
+    const float NeighborRadiusSq = FMath::Square(Component->NeighborRadius);
+
+    FVector SeparationForce = FVector::ZeroVector;
+    FVector RVOForce = FVector::ZeroVector;
+
+    const FIntVector CellKey = GetCellKey(Location);
+
+    for (int32 X = -1; X <= 1; ++X)
+    {
+        for (int32 Y = -1; Y <= 1; ++Y)
+        {
+            for (int32 Z = -1; Z <= 1; ++Z)
+            {
+                const FIntVector NeighborKey = CellKey + FIntVector(X, Y, Z);
+                const FSpatialCell* Cell = SpatialHash.Find(NeighborKey);
+                if (!Cell)
+                {
+                    continue;
+                }
+
+                for (const TWeakObjectPtr<UUnitAvoidanceComponent>& WeakOther : Cell->Components)
+                {
+                    UUnitAvoidanceComponent* Other = WeakOther.Get();
+                    if (!Other || Other == Component)
+                    {
+                        continue;
+                    }
+
+                    AActor* OtherOwner = Other->GetOwner();
+                    if (!OtherOwner)
+                    {
+                        continue;
+                    }
+
+                    const FVector OtherLocation = OtherOwner->GetActorLocation();
+                    const FVector ToOther = OtherLocation - Location;
+                    const float DistanceSq = ToOther.SizeSquared();
+
+                    if (DistanceSq < KINDA_SMALL_NUMBER || DistanceSq > NeighborRadiusSq)
+                    {
+                        continue;
+                    }
+
+                    const float Strength = (NeighborRadiusSq - DistanceSq) / NeighborRadiusSq;
+                    SeparationForce -= ToOther.GetSafeNormal() * Strength * Component->SeparationWeight;
+
+                    // RVO term: adjust relative velocity to avoid head-on collisions
+                    const FVector RelativeVelocity = Other->GetCurrentVelocity() - DesiredVelocity;
+                    const float ClosingSpeed = FVector::DotProduct(RelativeVelocity, ToOther.GetSafeNormal());
+                    if (ClosingSpeed < 0.f)
+                    {
+                        RVOForce -= RelativeVelocity * Component->RVOWeight;
+                    }
+                }
+            }
+        }
+    }
+
+    FVector Avoidance = SeparationForce + RVOForce;
+    Avoidance = Avoidance.GetClampedToMaxSize(Component->MaxAvoidanceForce);
+    return Avoidance;
+}
+
+FVector ADynamicPathManager::GetFlowDirectionAtLocation(const FVector& Location) const
+{
+    if (GridComponent)
+    {
+        return GridComponent->GetFlowDirectionAtLocation(Location);
+    }
+
+    return FVector::ZeroVector;
+}
+
+void ADynamicPathManager::MarkObstacle(const FVector& Location, const FVector& Extents, bool bBlocked)
+{
+    if (!GridComponent)
+    {
+        return;
+    }
+
+    const FVector Min = Location - Extents;
+    const FVector Max = Location + Extents;
+
+    const float InvVoxelSize = 1.f / FMath::Max(GridComponent->VoxelSize, 1.f);
+
+    FIntVector MinCoords;
+    MinCoords.X = FMath::FloorToInt((Min.X - GridComponent->GridOrigin.X) * InvVoxelSize);
+    MinCoords.Y = FMath::FloorToInt((Min.Y - GridComponent->GridOrigin.Y) * InvVoxelSize);
+    MinCoords.Z = FMath::FloorToInt((Min.Z - GridComponent->GridOrigin.Z) * InvVoxelSize);
+
+    FIntVector MaxCoords;
+    MaxCoords.X = FMath::CeilToInt((Max.X - GridComponent->GridOrigin.X) * InvVoxelSize);
+    MaxCoords.Y = FMath::CeilToInt((Max.Y - GridComponent->GridOrigin.Y) * InvVoxelSize);
+    MaxCoords.Z = FMath::CeilToInt((Max.Z - GridComponent->GridOrigin.Z) * InvVoxelSize);
+
+    for (int32 X = MinCoords.X; X <= MaxCoords.X; ++X)
+    {
+        for (int32 Y = MinCoords.Y; Y <= MaxCoords.Y; ++Y)
+        {
+            for (int32 Z = MinCoords.Z; Z <= MaxCoords.Z; ++Z)
+            {
+                GridComponent->SetVoxelBlocked(FIntVector(X, Y, Z), bBlocked);
+            }
+        }
+    }
+}
+
+FIntVector ADynamicPathManager::GetCellKey(const FVector& Location) const
+{
+    const float InvSize = 1.f / FMath::Max(SpatialHashCellSize, 1.f);
+    return FIntVector(
+        FMath::FloorToInt(Location.X * InvSize),
+        FMath::FloorToInt(Location.Y * InvSize),
+        FMath::FloorToInt(Location.Z * InvSize));
+}
+
+void ADynamicPathManager::RemoveComponentFromCell(UUnitAvoidanceComponent* Component, const FIntVector& CellKey)
+{
+    if (FSpatialCell* Cell = SpatialHash.Find(CellKey))
+    {
+        Cell->Components.Remove(Component);
+        if (Cell->Components.Num() == 0)
+        {
+            SpatialHash.Remove(CellKey);
+        }
+    }
+}
+
+void ADynamicPathManager::DrawAvoidanceDebug() const
+{
+    if (!GetWorld())
+    {
+        return;
+    }
+
+    for (const auto& Pair : SpatialHash)
+    {
+        const FIntVector Key = Pair.Key;
+        const FVector CellCenter = FVector(Key) * SpatialHashCellSize + FVector(SpatialHashCellSize * 0.5f);
+        DrawDebugBox(GetWorld(), CellCenter, FVector(SpatialHashCellSize * 0.5f), FColor::Yellow, false, -1.f, 0, 2.f);
+    }
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/DynamicPathfindingRuntime.cpp
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/DynamicPathfindingRuntime.cpp
@@ -1,0 +1,12 @@
+#include "DynamicPathfindingRuntime.h"
+#include "Modules/ModuleManager.h"
+
+IMPLEMENT_MODULE(FDynamicPathfindingRuntimeModule, DynamicPathfindingRuntime);
+
+void FDynamicPathfindingRuntimeModule::StartupModule()
+{
+}
+
+void FDynamicPathfindingRuntimeModule::ShutdownModule()
+{
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/GridNavigationComponent.cpp
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/GridNavigationComponent.cpp
@@ -1,0 +1,482 @@
+#include "GridNavigationComponent.h"
+#include "DrawDebugHelpers.h"
+#include "Async/Async.h"
+#include "Containers/Queue.h"
+#include "Engine/World.h"
+
+UGridNavigationComponent::UGridNavigationComponent()
+{
+    PrimaryComponentTick.bCanEverTick = false;
+
+    GridSize = FIntVector(64, 64, 8);
+    VoxelSize = 100.f;
+    GridOrigin = FVector::ZeroVector;
+    DirtyPropagationDepth = 6;
+    bDrawDebug = false;
+    DebugDrawDuration = 0.1f;
+
+    NumVoxels = 0;
+    bHasValidFlowField = false;
+    bHasDirtyRegion = false;
+    bPendingFullRebuild = true;
+    bAsyncTaskRunning = false;
+    bDestroying = false;
+}
+
+void UGridNavigationComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    InitializeGrid();
+    RequestFlowFieldRebuild(true);
+}
+
+void UGridNavigationComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    bDestroying = true;
+    Super::EndPlay(EndPlayReason);
+}
+
+void UGridNavigationComponent::InitializeGrid()
+{
+    NumVoxels = GridSize.X * GridSize.Y * GridSize.Z;
+    WalkableFlags.Init(1, NumVoxels);
+    FlowFieldDirections.Init(FVector::ZeroVector, NumVoxels);
+    DistanceField.Init(TNumericLimits<int32>::Max(), NumVoxels);
+}
+
+void UGridNavigationComponent::SetTargetLocation(const FVector& InTargetLocation, bool bImmediate /*= false*/)
+{
+    TargetLocation = InTargetLocation;
+    RequestFlowFieldRebuild(true);
+    if (bImmediate)
+    {
+        LaunchFlowFieldTask();
+    }
+}
+
+void UGridNavigationComponent::SetVoxelBlocked(const FIntVector& Coordinates, bool bBlocked)
+{
+    if (!IsValidCoordinates(Coordinates))
+    {
+        return;
+    }
+
+    const int32 Index = GetIndex(Coordinates);
+    {
+        FWriteScopeLock WriteLock(DataLock);
+        WalkableFlags[Index] = bBlocked ? 0 : 1;
+    }
+
+    ExpandDirtyRegion(Coordinates);
+    RequestFlowFieldRebuild(false);
+}
+
+FVector UGridNavigationComponent::GetFlowDirectionAtLocation(const FVector& WorldLocation) const
+{
+    if (NumVoxels == 0)
+    {
+        return FVector::ZeroVector;
+    }
+
+    const float InvVoxelSize = 1.f / FMath::Max(VoxelSize, 1.f);
+    FIntVector Coordinates;
+    Coordinates.X = FMath::FloorToInt((WorldLocation.X - GridOrigin.X) * InvVoxelSize);
+    Coordinates.Y = FMath::FloorToInt((WorldLocation.Y - GridOrigin.Y) * InvVoxelSize);
+    Coordinates.Z = FMath::FloorToInt((WorldLocation.Z - GridOrigin.Z) * InvVoxelSize);
+
+    if (!IsValidCoordinates(Coordinates))
+    {
+        return FVector::ZeroVector;
+    }
+
+    const int32 Index = GetIndex(Coordinates);
+
+    FReadScopeLock ReadLock(DataLock);
+    if (!bHasValidFlowField || !FlowFieldDirections.IsValidIndex(Index))
+    {
+        return FVector::ZeroVector;
+    }
+
+    return FlowFieldDirections[Index];
+}
+
+bool UGridNavigationComponent::IsVoxelWalkable(const FIntVector& Coordinates) const
+{
+    if (!IsValidCoordinates(Coordinates))
+    {
+        return false;
+    }
+
+    const int32 Index = GetIndex(Coordinates);
+
+    FReadScopeLock ReadLock(DataLock);
+    return WalkableFlags.IsValidIndex(Index) && WalkableFlags[Index] != 0;
+}
+
+void UGridNavigationComponent::SetDebugEnabled(bool bEnabled)
+{
+    bDrawDebug = bEnabled;
+}
+
+void UGridNavigationComponent::DrawDebug()
+{
+    if (!bDrawDebug)
+    {
+        return;
+    }
+
+    DrawDebugInternal();
+}
+
+void UGridNavigationComponent::RequestFlowFieldRebuild(bool bForceFullRebuild)
+{
+    bPendingFullRebuild |= bForceFullRebuild;
+    if (!bAsyncTaskRunning)
+    {
+        LaunchFlowFieldTask();
+    }
+}
+
+void UGridNavigationComponent::LaunchFlowFieldTask()
+{
+    if (bAsyncTaskRunning || NumVoxels <= 0 || bDestroying)
+    {
+        return;
+    }
+
+    bAsyncTaskRunning = true;
+
+    const bool bFullRebuild = bPendingFullRebuild;
+    FIntVector RegionMin = FIntVector::ZeroValue;
+    FIntVector RegionMax = GridSize - FIntVector(1, 1, 1);
+
+    if (!bFullRebuild && bHasDirtyRegion)
+    {
+        RegionMin = DirtyMin - FIntVector(DirtyPropagationDepth);
+        RegionMax = DirtyMax + FIntVector(DirtyPropagationDepth);
+        RegionMin = RegionMin.ComponentMax(FIntVector::ZeroValue);
+        RegionMax = RegionMax.ComponentMin(GridSize - FIntVector(1, 1, 1));
+    }
+
+    const FVector LocalTarget = TargetLocation;
+    const int32 LocalNumVoxels = NumVoxels;
+    const FIntVector LocalGridSize = GridSize;
+    const float LocalVoxelSize = VoxelSize;
+    const FVector LocalOrigin = GridOrigin;
+
+    TArray<uint8> WalkableCopy;
+    TArray<int32> ExistingDistance;
+    TArray<FVector> ExistingFlow;
+    {
+        FReadScopeLock ReadLock(DataLock);
+        WalkableCopy = WalkableFlags;
+        ExistingDistance = DistanceField;
+        ExistingFlow = FlowFieldDirections;
+    }
+
+    TWeakObjectPtr<UGridNavigationComponent> WeakThis(this);
+
+    Async(EAsyncExecution::ThreadPool, [WeakThis, WalkableCopy = MoveTemp(WalkableCopy), ExistingDistance = MoveTemp(ExistingDistance), ExistingFlow = MoveTemp(ExistingFlow), LocalGridSize, LocalVoxelSize, LocalOrigin, RegionMin, RegionMax, LocalTarget, LocalNumVoxels, bFullRebuild]() mutable
+    {
+        if (!WeakThis.IsValid())
+        {
+            return;
+        }
+
+        TArray<int32> NewDistance = ExistingDistance;
+        TArray<FVector> NewFlowField = ExistingFlow;
+
+        if (bFullRebuild || NewDistance.Num() != LocalNumVoxels)
+        {
+            NewDistance.Init(TNumericLimits<int32>::Max(), LocalNumVoxels);
+        }
+        if (bFullRebuild || NewFlowField.Num() != LocalNumVoxels)
+        {
+            NewFlowField.Init(FVector::ZeroVector, LocalNumVoxels);
+        }
+
+        auto IndexFromCoords = [LocalGridSize](const FIntVector& Coords)
+        {
+            return (Coords.Z * LocalGridSize.Y * LocalGridSize.X) + (Coords.Y * LocalGridSize.X) + Coords.X;
+        };
+
+        auto IsValidCoord = [LocalGridSize](const FIntVector& Coords) -> bool
+        {
+            return Coords.X >= 0 && Coords.Y >= 0 && Coords.Z >= 0 &&
+                   Coords.X < LocalGridSize.X && Coords.Y < LocalGridSize.Y && Coords.Z < LocalGridSize.Z;
+        };
+
+        auto GetCoordsFromIndex = [LocalGridSize](int32 Index)
+        {
+            const int32 XYSize = LocalGridSize.X * LocalGridSize.Y;
+            const int32 Z = Index / XYSize;
+            const int32 Remainder = Index % XYSize;
+            const int32 Y = Remainder / LocalGridSize.X;
+            const int32 X = Remainder % LocalGridSize.X;
+            return FIntVector(X, Y, Z);
+        };
+
+        auto GetVoxelCenter = [LocalOrigin, LocalVoxelSize](const FIntVector& Coords)
+        {
+            return LocalOrigin + FVector(Coords) * LocalVoxelSize + FVector(LocalVoxelSize * 0.5f);
+        };
+
+        const bool bLimitRegion = !bFullRebuild;
+        FIntVector LocalMinRegion = RegionMin;
+        FIntVector LocalMaxRegion = RegionMax;
+
+        const float InvVoxelSize = 1.f / FMath::Max(LocalVoxelSize, 1.f);
+        FIntVector GoalCoords;
+        GoalCoords.X = FMath::RoundToInt((LocalTarget.X - LocalOrigin.X) * InvVoxelSize);
+        GoalCoords.Y = FMath::RoundToInt((LocalTarget.Y - LocalOrigin.Y) * InvVoxelSize);
+        GoalCoords.Z = FMath::RoundToInt((LocalTarget.Z - LocalOrigin.Z) * InvVoxelSize);
+
+        GoalCoords = GoalCoords.ComponentMax(FIntVector::ZeroValue);
+        GoalCoords = GoalCoords.ComponentMin(LocalGridSize - FIntVector(1, 1, 1));
+
+        const int32 GoalIndex = IndexFromCoords(GoalCoords);
+
+        if (bLimitRegion)
+        {
+            LocalMinRegion = LocalMinRegion.ComponentMin(GoalCoords);
+            LocalMaxRegion = LocalMaxRegion.ComponentMax(GoalCoords);
+        }
+
+        if (!WalkableCopy.IsValidIndex(GoalIndex) || WalkableCopy[GoalIndex] == 0)
+        {
+            AsyncTask(ENamedThreads::GameThread, [WeakThis]()
+            {
+                if (UGridNavigationComponent* StrongThis = WeakThis.Get())
+                {
+                    StrongThis->bAsyncTaskRunning = false;
+                    StrongThis->bHasValidFlowField = false;
+                }
+            });
+            return;
+        }
+
+        TQueue<int32> OpenSet;
+        NewDistance[GoalIndex] = 0;
+        OpenSet.Enqueue(GoalIndex);
+
+        while (!OpenSet.IsEmpty())
+        {
+            int32 CurrentIndex;
+            OpenSet.Dequeue(CurrentIndex);
+
+            const FIntVector CurrentCoords = GetCoordsFromIndex(CurrentIndex);
+
+            if (bLimitRegion)
+            {
+                if (CurrentCoords.X < LocalMinRegion.X || CurrentCoords.Y < LocalMinRegion.Y || CurrentCoords.Z < LocalMinRegion.Z ||
+                    CurrentCoords.X > LocalMaxRegion.X || CurrentCoords.Y > LocalMaxRegion.Y || CurrentCoords.Z > LocalMaxRegion.Z)
+                {
+                    continue;
+                }
+            }
+
+            const int32 CurrentDistance = NewDistance[CurrentIndex];
+            static const FIntVector NeighborOffsets[6] = {
+                FIntVector(1, 0, 0), FIntVector(-1, 0, 0),
+                FIntVector(0, 1, 0), FIntVector(0, -1, 0),
+                FIntVector(0, 0, 1), FIntVector(0, 0, -1)};
+
+            for (const FIntVector& Offset : NeighborOffsets)
+            {
+                FIntVector NeighborCoords = CurrentCoords + Offset;
+                if (!IsValidCoord(NeighborCoords))
+                {
+                    continue;
+                }
+
+                if (bLimitRegion)
+                {
+                    if (NeighborCoords.X < LocalMinRegion.X || NeighborCoords.Y < LocalMinRegion.Y || NeighborCoords.Z < LocalMinRegion.Z ||
+                        NeighborCoords.X > LocalMaxRegion.X || NeighborCoords.Y > LocalMaxRegion.Y || NeighborCoords.Z > LocalMaxRegion.Z)
+                    {
+                        continue;
+                    }
+                }
+
+                const int32 NeighborIndex = IndexFromCoords(NeighborCoords);
+                if (!WalkableCopy.IsValidIndex(NeighborIndex) || WalkableCopy[NeighborIndex] == 0)
+                {
+                    continue;
+                }
+
+                const int32 NewCost = CurrentDistance + 1;
+                if (NewCost < NewDistance[NeighborIndex])
+                {
+                    NewDistance[NeighborIndex] = NewCost;
+                    OpenSet.Enqueue(NeighborIndex);
+                }
+            }
+        }
+
+        for (int32 Index = 0; Index < LocalNumVoxels; ++Index)
+        {
+            if (NewDistance[Index] == TNumericLimits<int32>::Max())
+            {
+                NewFlowField[Index] = FVector::ZeroVector;
+                continue;
+            }
+
+            const FIntVector Coords = GetCoordsFromIndex(Index);
+            if (bLimitRegion)
+            {
+                if (Coords.X < LocalMinRegion.X || Coords.Y < LocalMinRegion.Y || Coords.Z < LocalMinRegion.Z ||
+                    Coords.X > LocalMaxRegion.X || Coords.Y > LocalMaxRegion.Y || Coords.Z > LocalMaxRegion.Z)
+                {
+                    continue;
+                }
+            }
+
+            float BestNeighborCost = static_cast<float>(NewDistance[Index]);
+            FVector BestDirection = FVector::ZeroVector;
+
+            static const FIntVector NeighborOffsets2[6] = {
+                FIntVector(1, 0, 0), FIntVector(-1, 0, 0),
+                FIntVector(0, 1, 0), FIntVector(0, -1, 0),
+                FIntVector(0, 0, 1), FIntVector(0, 0, -1)};
+
+            for (const FIntVector& Offset : NeighborOffsets2)
+            {
+                FIntVector NeighborCoords = Coords + Offset;
+                if (!IsValidCoord(NeighborCoords))
+                {
+                    continue;
+                }
+
+                const int32 NeighborIndex = IndexFromCoords(NeighborCoords);
+                if (!WalkableCopy.IsValidIndex(NeighborIndex) || WalkableCopy[NeighborIndex] == 0)
+                {
+                    continue;
+                }
+
+                const int32 NeighborCost = NewDistance[NeighborIndex];
+                if (NeighborCost < BestNeighborCost)
+                {
+                    BestNeighborCost = NeighborCost;
+                    BestDirection = (GetVoxelCenter(NeighborCoords) - GetVoxelCenter(Coords)).GetSafeNormal();
+                }
+            }
+
+            NewFlowField[Index] = BestDirection;
+        }
+
+        AsyncTask(ENamedThreads::GameThread, [WeakThis, Distance = MoveTemp(NewDistance), FlowField = MoveTemp(NewFlowField), bFullRebuild]() mutable
+        {
+            if (UGridNavigationComponent* StrongThis = WeakThis.Get())
+            {
+                StrongThis->CompleteFlowFieldTask(MoveTemp(Distance), MoveTemp(FlowField));
+                StrongThis->bPendingFullRebuild = false;
+                if (!bFullRebuild)
+                {
+                    StrongThis->ClearDirtyRegion();
+                }
+            }
+        });
+    });
+}
+
+void UGridNavigationComponent::CompleteFlowFieldTask(TArray<int32>&& InDistanceField, TArray<FVector>&& InFlowField)
+{
+    {
+        FWriteScopeLock WriteLock(DataLock);
+        DistanceField = MoveTemp(InDistanceField);
+        FlowFieldDirections = MoveTemp(InFlowField);
+        bHasValidFlowField = true;
+    }
+
+    bAsyncTaskRunning = false;
+
+    if (bHasDirtyRegion || bPendingFullRebuild)
+    {
+        LaunchFlowFieldTask();
+    }
+}
+
+bool UGridNavigationComponent::IsValidCoordinates(const FIntVector& Coordinates) const
+{
+    return Coordinates.X >= 0 && Coordinates.Y >= 0 && Coordinates.Z >= 0 &&
+           Coordinates.X < GridSize.X && Coordinates.Y < GridSize.Y && Coordinates.Z < GridSize.Z;
+}
+
+int32 UGridNavigationComponent::GetIndex(const FIntVector& Coordinates) const
+{
+    return (Coordinates.Z * GridSize.Y * GridSize.X) + (Coordinates.Y * GridSize.X) + Coordinates.X;
+}
+
+FIntVector UGridNavigationComponent::GetCoordinatesFromIndex(int32 Index) const
+{
+    const int32 XYSize = GridSize.X * GridSize.Y;
+    const int32 Z = Index / XYSize;
+    const int32 Remainder = Index % XYSize;
+    const int32 Y = Remainder / GridSize.X;
+    const int32 X = Remainder % GridSize.X;
+    return FIntVector(X, Y, Z);
+}
+
+FVector UGridNavigationComponent::GetVoxelCenter(const FIntVector& Coordinates) const
+{
+    return GridOrigin + FVector(Coordinates) * VoxelSize + FVector(VoxelSize * 0.5f);
+}
+
+void UGridNavigationComponent::ExpandDirtyRegion(const FIntVector& Coordinates)
+{
+    if (!bHasDirtyRegion)
+    {
+        DirtyMin = Coordinates;
+        DirtyMax = Coordinates;
+        bHasDirtyRegion = true;
+        return;
+    }
+
+    DirtyMin = DirtyMin.ComponentMin(Coordinates);
+    DirtyMax = DirtyMax.ComponentMax(Coordinates);
+}
+
+void UGridNavigationComponent::ClearDirtyRegion()
+{
+    bHasDirtyRegion = false;
+}
+
+void UGridNavigationComponent::DrawDebugInternal() const
+{
+    if (!GetWorld())
+    {
+        return;
+    }
+
+    const float HalfVoxel = VoxelSize * 0.5f;
+
+    FReadScopeLock ReadLock(DataLock);
+    if (!bHasValidFlowField)
+    {
+        return;
+    }
+
+    for (int32 Index = 0; Index < FlowFieldDirections.Num(); ++Index)
+    {
+        const FIntVector Coords = GetCoordinatesFromIndex(Index);
+        const FVector Center = GetVoxelCenter(Coords);
+
+        const bool bWalkable = WalkableFlags.IsValidIndex(Index) && WalkableFlags[Index] != 0;
+        const FColor BoxColor = bWalkable ? FColor::Green : FColor::Red;
+
+        DrawDebugBox(GetWorld(), Center, FVector(HalfVoxel), BoxColor, false, DebugDrawDuration, 0, 1.f);
+
+        const FVector Direction = FlowFieldDirections[Index];
+        if (!Direction.IsNearlyZero())
+        {
+            DrawDebugDirectionalArrow(GetWorld(), Center, Center + Direction * VoxelSize * 0.5f, 15.f, FColor::Blue, false, DebugDrawDuration, 0, 1.5f);
+        }
+    }
+}
+
+void UGridNavigationComponent::BuildFlowFieldData(const FIntVector& RegionMin, const FIntVector& RegionMax, TArray<int32>& OutDistance, TArray<FVector>& OutFlowField) const
+{
+    // Unused placeholder for potential future specialized implementations.
+    // Flow field generation is handled directly inside LaunchFlowFieldTask for simplicity.
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/UnitAvoidanceComponent.cpp
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/UnitAvoidanceComponent.cpp
@@ -1,0 +1,72 @@
+#include "UnitAvoidanceComponent.h"
+#include "DynamicPathManager.h"
+#include "GameFramework/Actor.h"
+
+UUnitAvoidanceComponent::UUnitAvoidanceComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+    PrimaryComponentTick.TickGroup = TG_PrePhysics;
+
+    NeighborRadius = 200.f;
+    SeparationWeight = 1.5f;
+    MaxAvoidanceForce = 600.f;
+    RVOWeight = 0.6f;
+
+    SpatialCellKey = FIntVector::ZeroValue;
+}
+
+void UUnitAvoidanceComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    LastWorldLocation = GetOwner() ? GetOwner()->GetActorLocation() : FVector::ZeroVector;
+}
+
+void UUnitAvoidanceComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (ADynamicPathManager* StrongManager = Manager.Get())
+    {
+        StrongManager->UnregisterAvoidanceComponent(this);
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UUnitAvoidanceComponent::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (!GetOwner())
+    {
+        return;
+    }
+
+    const FVector CurrentLocation = GetOwner()->GetActorLocation();
+    CurrentVelocity = (CurrentLocation - LastWorldLocation) / FMath::Max(DeltaTime, UE_SMALL_NUMBER);
+    LastWorldLocation = CurrentLocation;
+
+    if (ADynamicPathManager* StrongManager = Manager.Get())
+    {
+        StrongManager->UpdateSpatialEntry(this, CurrentLocation);
+    }
+}
+
+FVector UUnitAvoidanceComponent::ComputeAvoidance(const FVector& DesiredVelocity) const
+{
+    if (ADynamicPathManager* StrongManager = Manager.Get())
+    {
+        return StrongManager->ComputeAvoidanceForComponent(this, DesiredVelocity);
+    }
+
+    return FVector::ZeroVector;
+}
+
+void UUnitAvoidanceComponent::SetManager(ADynamicPathManager* InManager)
+{
+    Manager = InManager;
+}
+
+void UUnitAvoidanceComponent::UpdateSpatialCellKey(const FIntVector& NewKey)
+{
+    SpatialCellKey = NewKey;
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/UnitNavigationComponent.cpp
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Private/UnitNavigationComponent.cpp
@@ -1,0 +1,116 @@
+#include "UnitNavigationComponent.h"
+#include "DynamicPathManager.h"
+#include "UnitAvoidanceComponent.h"
+#include "GameFramework/Actor.h"
+#include "EngineUtils.h"
+
+UUnitNavigationComponent::UUnitNavigationComponent()
+{
+    PrimaryComponentTick.bCanEverTick = true;
+
+    MoveSpeed = 600.f;
+    AvoidanceStrength = 1.0f;
+    MaxSpeed = 900.f;
+
+    AvoidanceComponent = nullptr;
+}
+
+void UUnitNavigationComponent::BeginPlay()
+{
+    Super::BeginPlay();
+
+    AvoidanceComponent = GetOwner() ? GetOwner()->FindComponentByClass<UUnitAvoidanceComponent>() : nullptr;
+    EnsureManagerReference();
+
+    if (ADynamicPathManager* StrongManager = Manager.Get())
+    {
+        StrongManager->RegisterUnit(this);
+        if (AvoidanceComponent)
+        {
+            StrongManager->RegisterAvoidanceComponent(AvoidanceComponent);
+        }
+    }
+}
+
+void UUnitNavigationComponent::EndPlay(const EEndPlayReason::Type EndPlayReason)
+{
+    if (ADynamicPathManager* StrongManager = Manager.Get())
+    {
+        StrongManager->UnregisterUnit(this);
+        if (AvoidanceComponent)
+        {
+            StrongManager->UnregisterAvoidanceComponent(AvoidanceComponent);
+        }
+    }
+
+    Super::EndPlay(EndPlayReason);
+}
+
+void UUnitNavigationComponent::TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
+{
+    Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
+
+    if (!GetOwner())
+    {
+        return;
+    }
+
+    if (!Manager.IsValid())
+    {
+        EnsureManagerReference();
+    }
+
+    ADynamicPathManager* StrongManager = Manager.Get();
+    if (!StrongManager)
+    {
+        return;
+    }
+
+    const FVector FlowDirection = StrongManager->GetFlowDirectionAtLocation(GetOwner()->GetActorLocation());
+    FVector DesiredVelocity = FlowDirection * MoveSpeed;
+
+    if (AvoidanceComponent)
+    {
+        const FVector AvoidanceVelocity = AvoidanceComponent->ComputeAvoidance(DesiredVelocity);
+        DesiredVelocity += AvoidanceVelocity * AvoidanceStrength;
+    }
+
+    DesiredVelocity = DesiredVelocity.GetClampedToMaxSize(MaxSpeed);
+
+    CurrentVelocity = DesiredVelocity;
+
+    ApplyMovement(CurrentVelocity, DeltaTime);
+}
+
+void UUnitNavigationComponent::EnsureManagerReference()
+{
+    if (Manager.IsValid())
+    {
+        return;
+    }
+
+    if (!GetWorld())
+    {
+        return;
+    }
+
+    for (TActorIterator<ADynamicPathManager> It(GetWorld()); It; ++It)
+    {
+        Manager = *It;
+        break;
+    }
+}
+
+void UUnitNavigationComponent::SetManager(ADynamicPathManager* InManager)
+{
+    Manager = InManager;
+}
+
+void UUnitNavigationComponent::ApplyMovement(const FVector& Velocity, float DeltaTime)
+{
+    if (AActor* OwnerActor = GetOwner())
+    {
+        const FVector Delta = Velocity * DeltaTime;
+        OwnerActor->AddActorWorldOffset(Delta, true);
+    }
+}

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/DynamicPathManager.h
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/DynamicPathManager.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "DynamicPathManager.generated.h"
+
+class UGridNavigationComponent;
+class UUnitNavigationComponent;
+class UUnitAvoidanceComponent;
+
+USTRUCT()
+struct FDynamicAvoidanceNeighbor
+{
+    GENERATED_BODY()
+
+    UPROPERTY()
+    TWeakObjectPtr<UUnitAvoidanceComponent> Component;
+
+    UPROPERTY()
+    FVector Location;
+
+    UPROPERTY()
+    FVector Velocity;
+};
+
+UCLASS()
+class DYNAMICPATHFINDINGRUNTIME_API ADynamicPathManager : public AActor
+{
+    GENERATED_BODY()
+
+public:
+    ADynamicPathManager();
+
+    virtual void Tick(float DeltaSeconds) override;
+    virtual void BeginPlay() override;
+
+    /** Voxel grid responsible for global navigation. */
+    UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Navigation")
+    UGridNavigationComponent* GridComponent;
+
+    /** Size of the spatial hashing cells used for avoidance lookups. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Avoidance")
+    float SpatialHashCellSize;
+
+    /** Enables or disables debug rendering for the grid. */
+    UFUNCTION(BlueprintCallable, Category = "Dynamic Pathfinding")
+    void SetDebugEnabled(bool bEnabled);
+
+    /** Blueprint callable helper to update the navigation target. */
+    UFUNCTION(BlueprintCallable, Category = "Dynamic Pathfinding")
+    void SetTargetLocation(const FVector& TargetLocation);
+
+    /** Console helper to toggle debug drawing. */
+    UFUNCTION(Exec)
+    void ToggleDynamicPathDebug();
+
+    /** Allows units to register/unregister with the manager. */
+    void RegisterUnit(UUnitNavigationComponent* UnitComponent);
+    void UnregisterUnit(UUnitNavigationComponent* UnitComponent);
+
+    void RegisterAvoidanceComponent(UUnitAvoidanceComponent* Component);
+    void UnregisterAvoidanceComponent(UUnitAvoidanceComponent* Component);
+
+    void UpdateSpatialEntry(UUnitAvoidanceComponent* Component, const FVector& Location);
+
+    FVector ComputeAvoidanceForComponent(const UUnitAvoidanceComponent* Component, const FVector& DesiredVelocity) const;
+
+    FVector GetFlowDirectionAtLocation(const FVector& Location) const;
+
+    void MarkObstacle(const FVector& Location, const FVector& Extents, bool bBlocked);
+
+protected:
+    virtual void PostRegisterAllComponents() override;
+
+private:
+    struct FSpatialCell
+    {
+        TArray<TWeakObjectPtr<UUnitAvoidanceComponent>> Components;
+    };
+
+    TSet<TWeakObjectPtr<UUnitNavigationComponent>> RegisteredUnits;
+
+    TMap<FIntVector, FSpatialCell> SpatialHash;
+
+    FIntVector GetCellKey(const FVector& Location) const;
+
+    void RemoveComponentFromCell(UUnitAvoidanceComponent* Component, const FIntVector& CellKey);
+
+    void DrawAvoidanceDebug() const;
+
+    UPROPERTY(EditAnywhere, Category = "Debug")
+    bool bDrawAvoidanceDebug;
+};

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/DynamicPathfindingRuntime.h
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/DynamicPathfindingRuntime.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "Modules/ModuleManager.h"
+
+class FDynamicPathfindingRuntimeModule : public IModuleInterface
+{
+public:
+    virtual void StartupModule() override;
+    virtual void ShutdownModule() override;
+};

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/GridNavigationComponent.h
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/GridNavigationComponent.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "HAL/RWLock.h"
+#include "HAL/ThreadSafeBool.h"
+#include "GridNavigationComponent.generated.h"
+
+class ADynamicPathManager;
+
+/**
+ * Component responsible for maintaining a voxelized representation of the world and generating
+ * flow field data that units can use to reach their target destination.
+ */
+UCLASS(ClassGroup = (Navigation), meta = (BlueprintSpawnableComponent))
+class DYNAMICPATHFINDINGRUNTIME_API UGridNavigationComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UGridNavigationComponent();
+
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+
+    /** Size of the grid in voxels. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid")
+    FIntVector GridSize;
+
+    /** Uniform size of a voxel in world units. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid")
+    float VoxelSize;
+
+    /** World-space origin of the grid (corner at index 0,0,0). */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Grid")
+    FVector GridOrigin;
+
+    /** How far dirty regions expand when recomputing the flow field. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "FlowField")
+    int32 DirtyPropagationDepth;
+
+    /** Whether to render debug information for the voxel grid and flow field. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug")
+    bool bDrawDebug;
+
+    /** Duration for debug primitives. */
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Debug")
+    float DebugDrawDuration;
+
+    /** Sets the current goal location for the flow field and triggers regeneration. */
+    void SetTargetLocation(const FVector& InTargetLocation, bool bImmediate = false);
+
+    /** Marks a voxel as blocked or walkable. */
+    void SetVoxelBlocked(const FIntVector& Coordinates, bool bBlocked);
+
+    /** Returns the normalized flow direction for a given world position. */
+    FVector GetFlowDirectionAtLocation(const FVector& WorldLocation) const;
+
+    /** Queries whether a voxel is marked as walkable. */
+    bool IsVoxelWalkable(const FIntVector& Coordinates) const;
+
+    /** Enables or disables debug drawing. */
+    void SetDebugEnabled(bool bEnabled);
+
+    /** Draws debug visualization if enabled. */
+    void DrawDebug();
+
+    FORCEINLINE FVector GetTargetLocation() const { return TargetLocation; }
+
+protected:
+    void InitializeGrid();
+
+    void RequestFlowFieldRebuild(bool bForceFullRebuild);
+
+    void LaunchFlowFieldTask();
+
+    void CompleteFlowFieldTask(TArray<int32>&& InDistanceField, TArray<FVector>&& InFlowField);
+
+    bool IsValidCoordinates(const FIntVector& Coordinates) const;
+    int32 GetIndex(const FIntVector& Coordinates) const;
+    FIntVector GetCoordinatesFromIndex(int32 Index) const;
+    FVector GetVoxelCenter(const FIntVector& Coordinates) const;
+
+    void ExpandDirtyRegion(const FIntVector& Coordinates);
+
+    void ClearDirtyRegion();
+
+private:
+    int32 NumVoxels;
+
+    FVector TargetLocation;
+
+    UPROPERTY(Transient)
+    TArray<uint8> WalkableFlags;
+
+    UPROPERTY(Transient)
+    TArray<FVector> FlowFieldDirections;
+
+    UPROPERTY(Transient)
+    TArray<int32> DistanceField;
+
+    mutable FRWLock DataLock;
+
+    bool bHasValidFlowField;
+
+    FIntVector DirtyMin;
+    FIntVector DirtyMax;
+    bool bHasDirtyRegion;
+    bool bPendingFullRebuild;
+
+    FThreadSafeBool bAsyncTaskRunning;
+    FThreadSafeBool bDestroying;
+
+    void BuildFlowFieldData(const FIntVector& RegionMin, const FIntVector& RegionMax, TArray<int32>& OutDistance, TArray<FVector>& OutFlowField) const;
+
+    void DrawDebugInternal() const;
+};

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/UnitAvoidanceComponent.h
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/UnitAvoidanceComponent.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "UnitAvoidanceComponent.generated.h"
+
+class ADynamicPathManager;
+
+/**
+ * Handles local avoidance between units using a lightweight spatial hashing grid.
+ */
+UCLASS(ClassGroup = (Navigation), meta = (BlueprintSpawnableComponent))
+class DYNAMICPATHFINDINGRUNTIME_API UUnitAvoidanceComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UUnitAvoidanceComponent();
+
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    /** Radius used to determine which neighbors influence the avoidance. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Avoidance")
+    float NeighborRadius;
+
+    /** Weight applied to the separation force. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Avoidance")
+    float SeparationWeight;
+
+    /** Maximum magnitude of the avoidance correction. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Avoidance")
+    float MaxAvoidanceForce;
+
+    /** Strength of reciprocal velocity obstacle adjustment. */
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Avoidance")
+    float RVOWeight;
+
+    /** Computes the avoidance velocity correction. */
+    FVector ComputeAvoidance(const FVector& DesiredVelocity) const;
+
+    /** Sets the manager responsible for spatial hashing. */
+    void SetManager(ADynamicPathManager* InManager);
+
+    /** Returns the most recent computed velocity. */
+    FVector GetCurrentVelocity() const { return CurrentVelocity; }
+
+    /** Internal use: updates the cached cell key. */
+    void UpdateSpatialCellKey(const FIntVector& NewKey);
+
+    FIntVector GetSpatialCellKey() const { return SpatialCellKey; }
+
+private:
+    TWeakObjectPtr<ADynamicPathManager> Manager;
+
+    FVector CurrentVelocity;
+
+    FVector LastWorldLocation;
+
+    FIntVector SpatialCellKey;
+};

--- a/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/UnitNavigationComponent.h
+++ b/Plugins/DynamicPathfindingPlugin/Source/DynamicPathfindingRuntime/Public/UnitNavigationComponent.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Components/ActorComponent.h"
+#include "UnitNavigationComponent.generated.h"
+
+class ADynamicPathManager;
+class UUnitAvoidanceComponent;
+
+/**
+ * Component responsible for combining flow field navigation with local avoidance for a unit.
+ */
+UCLASS(ClassGroup = (Navigation), meta = (BlueprintSpawnableComponent))
+class DYNAMICPATHFINDINGRUNTIME_API UUnitNavigationComponent : public UActorComponent
+{
+    GENERATED_BODY()
+
+public:
+    UUnitNavigationComponent();
+
+    virtual void BeginPlay() override;
+    virtual void EndPlay(const EEndPlayReason::Type EndPlayReason) override;
+    virtual void TickComponent(float DeltaTime, enum ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Navigation")
+    float MoveSpeed;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Navigation")
+    float AvoidanceStrength;
+
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Navigation")
+    float MaxSpeed;
+
+    /** Attempts to locate a manager in the world if one is not already assigned. */
+    void EnsureManagerReference();
+
+    void SetManager(ADynamicPathManager* InManager);
+
+private:
+    TWeakObjectPtr<ADynamicPathManager> Manager;
+
+    UPROPERTY()
+    UUnitAvoidanceComponent* AvoidanceComponent;
+
+    FVector CurrentVelocity;
+
+    void ApplyMovement(const FVector& Velocity, float DeltaTime);
+};


### PR DESCRIPTION
## Summary
- add the DynamicPathfindingPlugin runtime module and descriptor
- implement a voxel-based grid navigation component with async flow-field rebuilding and debug draw controls
- add manager, navigation, and avoidance components that register units, compute RVO-style steering via spatial hashing, and expose Blueprint toggles

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dac4d6d1888330b42b56708bc882f3