### PR TITLE
Sync multi-unit previews with formation

### DIFF
--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/UnitSpawnComponent.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Components/UnitSpawnComponent.h
@@ -39,6 +39,9 @@ public:
     UFUNCTION(BlueprintPure, Category = "RTS|Spawn")
     TSubclassOf<ASoldierRts> GetUnitToSpawn() const { return UnitToSpawn; }
 
+    UFUNCTION(BlueprintPure, Category = "RTS|Spawn")
+    float GetFormationSpacing() const { return FormationSpacing; }
+
     /** Delegate fired whenever the unit class changes (useful for UI preview). */
     UPROPERTY(BlueprintAssignable, Category = "RTS|Spawn")
     FOnSpawnUnitClassChangedSignature OnUnitClassChanged;

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Player/PlayerCamera.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Player/PlayerCamera.h
@@ -320,26 +320,33 @@ protected:
 	UFUNCTION()
 	void CreatePreviewMesh();
 	
-	UFUNCTION()
-	void Input_OnSpawnUnits();
+        UFUNCTION()
+        void Input_OnSpawnUnits();
 
-	UFUNCTION()
-	void ShowUnitPreview(TSubclassOf<ASoldierRts> NewUnitClass);
+        UFUNCTION()
+        void ShowUnitPreview(TSubclassOf<ASoldierRts> NewUnitClass);
 
-	UFUNCTION()
-	void HidePreview();
+        UFUNCTION()
+        void HidePreview();
 
-	UFUNCTION()
-	void PreviewFollowMouse();
+        UFUNCTION()
+        void PreviewFollowMouse();
 
-	UPROPERTY()
-	bool bIsInSpawnUnits = false;
-
-	UPROPERTY(EditAnywhere, Category = "Settings|Spawn Units")
-	TSubclassOf<APreviewPoseMesh> PreviewUnitsClass;
+        UFUNCTION()
+        void HandleSpawnCountChanged(int32 NewSpawnCount);
 
         UPROPERTY()
-        APreviewPoseMesh* PreviewUnits;
+        bool bIsInSpawnUnits = false;
+
+        UPROPERTY(EditAnywhere, Category = "Settings|Spawn Units")
+        TSubclassOf<APreviewPoseMesh> PreviewUnitsClass;
+
+        UPROPERTY()
+        TArray<TObjectPtr<APreviewPoseMesh>> PreviewUnits;
+
+        void EnsurePreviewUnits(int32 DesiredCount);
+        void UpdatePreviewTransforms(const FVector& CenterLocation, const FRotator& FacingRotation);
+        bool HasPreviewUnits() const { return PreviewUnits.Num() > 0; }
 
 #pragma endregion
 


### PR DESCRIPTION
## Summary
- create and manage multiple preview meshes so the spawn preview matches the multi-unit formation
- update preview positioning when the spawn count changes and reuse the server formation logic for offsets
- expose the formation spacing on the unit spawn component for preview placement

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dadd5d61708330b99153f20b9793a6