### PR TITLE
Refactor unit preview to single instanced actor

### DIFF
--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Player/PlayerCamera.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Player/PlayerCamera.h
@@ -342,11 +342,11 @@ protected:
         TSubclassOf<APreviewPoseMesh> PreviewUnitsClass;
 
         UPROPERTY()
-        TArray<TObjectPtr<APreviewPoseMesh>> PreviewUnits;
+        TObjectPtr<APreviewPoseMesh> PreviewUnit;
 
-        void EnsurePreviewUnits(int32 DesiredCount);
+        void EnsurePreviewUnit();
         void UpdatePreviewTransforms(const FVector& CenterLocation, const FRotator& FacingRotation);
-        bool HasPreviewUnits() const { return PreviewUnits.Num() > 0; }
+        bool HasPreviewUnits() const { return PreviewUnit != nullptr; }
 
 #pragma endregion
 

--- a/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Utilities/PreviewPoseMesh.h
+++ b/Plugins/JupiterPlugin/Source/JupiterPlugin/Public/Utilities/PreviewPoseMesh.h
@@ -4,41 +4,62 @@
 #include "PreviewPoseMesh.generated.h"
 
 
+class UInstancedStaticMeshComponent;
+class UPoseableMeshComponent;
+
 UCLASS()
 class JUPITERPLUGIN_API APreviewPoseMesh : public AActor
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
 public:
-	APreviewPoseMesh();
-	
-	UFUNCTION()
-	void ShowPreview(UStaticMesh* NewStaticMesh, FVector NewScale);
-	void ShowPreview(USkeletalMesh* NewSkeletalMesh, FVector NewScale);
+        APreviewPoseMesh();
 
-	UFUNCTION()
-	void HidePreview();
+        UFUNCTION()
+        void ShowPreview(UStaticMesh* NewStaticMesh, FVector NewScale, int32 InstanceCount);
+        void ShowPreview(USkeletalMesh* NewSkeletalMesh, FVector NewScale, int32 InstanceCount);
 
-	UFUNCTION()
-	void CheckIsValidPlacement();
+        UFUNCTION()
+        void UpdateInstances(const TArray<FTransform>& InstanceTransforms);
 
-	UFUNCTION()
-	bool GetIsValidPlacement();
+        UFUNCTION()
+        void HidePreview();
+
+        UFUNCTION()
+        void CheckIsValidPlacement();
+
+        UFUNCTION()
+        bool GetIsValidPlacement() const;
 
 protected:
 
-	UPROPERTY(EditAnywhere, Category = "Settings|Material")
-	UMaterialInstance* HighlightMaterial;
+        void EnsurePoseableComponents(int32 DesiredCount);
 
-	UPROPERTY()
-	UMaterialInstanceDynamic* MaterialInstance;
+        UPROPERTY(EditAnywhere, Category = "Settings|Material")
+        UMaterialInstance* HighlightMaterial;
 
-	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
-	UStaticMeshComponent* StaticMesh;
+        UPROPERTY()
+        UMaterialInstanceDynamic* StaticMaterialInstance;
 
-	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
-	USkeletalMeshComponent* SkeletalMesh;
+        UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
+        USceneComponent* Root;
 
-	UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
-	USceneComponent* Root;
+        UPROPERTY(EditAnywhere, meta = (AllowPrivateAccess = true))
+        UInstancedStaticMeshComponent* InstancedStaticMesh;
+
+        UPROPERTY()
+        TArray<UPoseableMeshComponent*> PoseableMeshes;
+
+        UPROPERTY()
+        TArray<UMaterialInstanceDynamic*> SkeletalMaterialInstances;
+
+        UPROPERTY()
+        FVector CurrentScale = FVector::OneVector;
+
+        UPROPERTY()
+        bool bUsingStaticMesh = false;
+
+        UPROPERTY()
+        bool bLastPlacementValid = true;
+
 };


### PR DESCRIPTION
## Summary
- replace the multi-actor preview system with a single preview actor that drives instanced/static representations
- update the player camera preview workflow to spawn and update the shared preview actor
- refresh highlight handling for instanced previews while keeping placement validation hooks

## Testing
- not run (Unreal project)


------
https://chatgpt.com/codex/tasks/task_e_68dadfff53788330998e1a1bd5b9805b