### PR TITLE
Add FlowFieldTestActor for in-game flow field testing

### DIFF
--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.cpp
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.cpp
@@ -1,0 +1,133 @@
+#include "FlowFieldTestActor.h"
+
+AFlowFieldTestActor::AFlowFieldTestActor()
+{
+        PrimaryActorTick.bCanEverTick = true;
+}
+
+void AFlowFieldTestActor::OnConstruction(const FTransform& Transform)
+{
+        Super::OnConstruction(Transform);
+        AnchorLocation = Transform.GetLocation();
+        UpdateFlowFieldSettings();
+}
+
+void AFlowFieldTestActor::BeginPlay()
+{
+        Super::BeginPlay();
+        AnchorLocation = GetActorLocation();
+        UpdateFlowFieldSettings();
+        bHasDestination = TryAssignNewDestination();
+}
+
+void AFlowFieldTestActor::Tick(float DeltaSeconds)
+{
+        Super::Tick(DeltaSeconds);
+
+        if (!bHasDestination)
+        {
+                AnchorLocation = GetActorLocation();
+                UpdateFlowFieldSettings();
+                bHasDestination = TryAssignNewDestination();
+                return;
+        }
+
+        const FVector FlowDirection = FlowField.GetDirectionForWorldPosition(GetActorLocation());
+        if (!FlowDirection.IsNearlyZero())
+        {
+                const FVector NewLocation = GetActorLocation() + (FlowDirection * MovementSpeed * DeltaSeconds);
+                SetActorLocation(NewLocation);
+        }
+        else
+        {
+                bHasDestination = false;
+                return;
+        }
+
+        if (HasReachedDestination())
+        {
+                bHasDestination = false;
+        }
+}
+
+void AFlowFieldTestActor::UpdateFlowFieldSettings()
+{
+        FlowFieldSettings.GridSize = GridSize;
+        FlowFieldSettings.CellSize = CellSize;
+        FlowFieldSettings.Origin = AnchorLocation - FVector(GridSize.X * CellSize * 0.5f, GridSize.Y * CellSize * 0.5f, 0.0f);
+        FlowFieldSettings.bAllowDiagonal = bAllowDiagonal;
+        FlowFieldSettings.DiagonalCostMultiplier = DiagonalCostMultiplier;
+        FlowFieldSettings.StepCost = StepCost;
+        FlowFieldSettings.CellTraversalWeightMultiplier = CellTraversalWeightMultiplier;
+        FlowFieldSettings.HeuristicWeight = HeuristicWeight;
+        FlowFieldSettings.bSmoothDirections = bSmoothDirections;
+
+        FlowField.ApplySettings(FlowFieldSettings);
+
+        const int32 ExpectedCells = GridSize.X * GridSize.Y;
+        if (ExpectedCells <= 0)
+        {
+                TraversalWeights.Reset();
+                return;
+        }
+
+        if (TraversalWeights.Num() != ExpectedCells)
+        {
+                TraversalWeights.Init(255, ExpectedCells);
+        }
+
+        FlowField.SetTraversalWeights(TraversalWeights);
+}
+
+bool AFlowFieldTestActor::TryAssignNewDestination()
+{
+        const FFlowFieldSettings& Settings = FlowField.GetSettings();
+        if (Settings.GridSize.X <= 0 || Settings.GridSize.Y <= 0)
+        {
+                return false;
+        }
+
+        const int32 MaxAttempts = FMath::Max(1, MaxDestinationAttempts);
+        const FIntPoint CurrentCell = FlowField.WorldToCell(GetActorLocation());
+        const float CellSizeValue = FMath::Max(Settings.CellSize, KINDA_SMALL_NUMBER);
+        const int32 RadiusInCells = FMath::Clamp(
+                FMath::RoundToInt(DestinationSearchRadius / CellSizeValue),
+                1,
+                FMath::Max(Settings.GridSize.X, Settings.GridSize.Y));
+
+        for (int32 Attempt = 0; Attempt < MaxAttempts; ++Attempt)
+        {
+                const int32 OffsetX = FMath::RandRange(-RadiusInCells, RadiusInCells);
+                const int32 OffsetY = FMath::RandRange(-RadiusInCells, RadiusInCells);
+                FIntPoint Candidate = CurrentCell + FIntPoint(OffsetX, OffsetY);
+                Candidate.X = FMath::Clamp(Candidate.X, 0, Settings.GridSize.X - 1);
+                Candidate.Y = FMath::Clamp(Candidate.Y, 0, Settings.GridSize.Y - 1);
+
+                if (Candidate == CurrentCell)
+                {
+                        continue;
+                }
+
+                if (!FlowField.IsWalkable(Candidate))
+                {
+                        continue;
+                }
+
+                if (!FlowField.Build(Candidate))
+                {
+                        continue;
+                }
+
+                CurrentDestination = FlowField.CellToWorld(Candidate);
+                return true;
+        }
+
+        return false;
+}
+
+bool AFlowFieldTestActor::HasReachedDestination() const
+{
+        const FVector CurrentLocation = GetActorLocation();
+        const float DistanceSquared = FVector::DistSquared2D(CurrentLocation, CurrentDestination);
+        return DistanceSquared <= FMath::Square(AcceptanceRadius);
+}

--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.h
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.h
@@ -1,0 +1,93 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+
+#include "FlowField.h"
+
+#include "FlowFieldTestActor.generated.h"
+
+/**
+ * Simple actor that roams around by following a flow field towards random destinations.
+ */
+UCLASS()
+class PLUGINSDEVELOPMENT_API AFlowFieldTestActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	AFlowFieldTestActor();
+
+	virtual void Tick(float DeltaSeconds) override;
+	virtual void OnConstruction(const FTransform& Transform) override;
+
+protected:
+	virtual void BeginPlay() override;
+
+private:
+	/** Rebuilds the flow field settings and traversal weights around the actor. */
+	void UpdateFlowFieldSettings();
+
+	/** Picks a new destination around the actor and rebuilds the flow field towards it. */
+	bool TryAssignNewDestination();
+
+	/** Returns true if the actor reached the current destination. */
+	bool HasReachedDestination() const;
+
+private:
+	/** Size of the flow field grid. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	FIntPoint GridSize = FIntPoint(32, 32);
+
+	/** Size of each flow field cell in world units. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float CellSize = 200.0f;
+
+	/** Whether diagonal movement is allowed when generating the flow field. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	bool bAllowDiagonal = true;
+
+	/** Cost multiplier for diagonal movement. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float DiagonalCostMultiplier = 1.41421356f;
+
+	/** Base traversal cost for every step. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float StepCost = 1.0f;
+
+	/** Traversal weight multiplier applied to each cell. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float CellTraversalWeightMultiplier = 1.0f;
+
+	/** Additional heuristic weight applied when evaluating neighbours. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float HeuristicWeight = 1.0f;
+
+	/** Whether the field should smooth the resulting directions. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	bool bSmoothDirections = true;
+
+	/** Search radius (in world units) used when picking a new random destination. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float DestinationSearchRadius = 2000.0f;
+
+	/** Distance threshold used to consider the destination reached. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float AcceptanceRadius = 100.0f;
+
+	/** Movement speed while following the flow field. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	float MovementSpeed = 600.0f;
+
+	/** Maximum number of attempts when searching for a new destination. */
+	UPROPERTY(EditAnywhere, Category = "Flow Field")
+	int32 MaxDestinationAttempts = 24;
+
+private:
+	FFlowField FlowField;
+	FFlowFieldSettings FlowFieldSettings;
+	TArray<uint8> TraversalWeights;
+	FVector CurrentDestination = FVector::ZeroVector;
+	FVector AnchorLocation = FVector::ZeroVector;
+	bool bHasDestination = false;
+};


### PR DESCRIPTION
## Summary
- add a FlowFieldTestActor that wanders by following the flow field towards random nearby destinations
- expose configurable parameters to tune grid size, movement speed, and destination search behaviour for debugging

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dba47fbc6883309b6abf3f3bcf1c5b