### PR TITLE
Add FlowField manager actor with debugging support

### DIFF
--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.cpp
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.cpp
@@ -1,0 +1,232 @@
+#include "FlowFieldManager.h"
+
+#include "DrawDebugHelpers.h"
+
+AFlowFieldManager::AFlowFieldManager()
+{
+        PrimaryActorTick.bCanEverTick = true;
+        PrimaryActorTick.bStartWithTickEnabled = true;
+}
+
+void AFlowFieldManager::Tick(float DeltaSeconds)
+{
+        Super::Tick(DeltaSeconds);
+        DrawDebug();
+}
+
+void AFlowFieldManager::OnConstruction(const FTransform& Transform)
+{
+        Super::OnConstruction(Transform);
+        UpdateFlowFieldSettings();
+        UpdateTraversalWeights();
+}
+
+void AFlowFieldManager::BeginPlay()
+{
+        Super::BeginPlay();
+        UpdateFlowFieldSettings();
+        UpdateTraversalWeights();
+}
+
+bool AFlowFieldManager::BuildFlowFieldToCell(const FIntPoint& DestinationCell)
+{
+        if (FlowField.Build(DestinationCell))
+        {
+                bHasBuiltField = true;
+                CachedDestinationWorld = FlowField.CellToWorld(DestinationCell);
+                RefreshDebugSnapshot();
+                return true;
+        }
+
+        bHasBuiltField = false;
+        bHasDebugSnapshot = false;
+        CachedDestinationWorld = FVector::ZeroVector;
+        return false;
+}
+
+bool AFlowFieldManager::BuildFlowFieldToWorldLocation(const FVector& DestinationLocation)
+{
+        const FIntPoint Cell = FlowField.WorldToCell(DestinationLocation);
+        return BuildFlowFieldToCell(Cell);
+}
+
+FVector AFlowFieldManager::GetDirectionForWorldPosition(const FVector& WorldPosition) const
+{
+        if (!bHasBuiltField)
+        {
+                return FVector::ZeroVector;
+        }
+
+        return FlowField.GetDirectionForWorldPosition(WorldPosition);
+}
+
+void AFlowFieldManager::UpdateFlowFieldSettings()
+{
+        FlowFieldSettings.GridSize = GridSize;
+        FlowFieldSettings.CellSize = CellSize;
+
+        const FVector ActorLocation = GetActorLocation();
+        const FVector GridHalfExtent = FVector(GridSize.X * CellSize * 0.5f, GridSize.Y * CellSize * 0.5f, 0.0f);
+        FlowFieldSettings.Origin = ActorLocation - GridHalfExtent + AdditionalOriginOffset;
+        FlowFieldSettings.Origin.Z = ActorLocation.Z + AdditionalOriginOffset.Z;
+
+        FlowFieldSettings.bAllowDiagonal = bAllowDiagonal;
+        FlowFieldSettings.DiagonalCostMultiplier = DiagonalCostMultiplier;
+        FlowFieldSettings.StepCost = StepCost;
+        FlowFieldSettings.CellTraversalWeightMultiplier = CellTraversalWeightMultiplier;
+        FlowFieldSettings.HeuristicWeight = HeuristicWeight;
+        FlowFieldSettings.bSmoothDirections = bSmoothDirections;
+
+        FlowField.ApplySettings(FlowFieldSettings);
+        bHasBuiltField = false;
+        bHasDebugSnapshot = false;
+}
+
+void AFlowFieldManager::UpdateTraversalWeights()
+{
+        const int32 NumCells = FlowFieldSettings.GridSize.X * FlowFieldSettings.GridSize.Y;
+        if (NumCells <= 0)
+        {
+                TraversalWeights.Reset();
+                FlowField.SetTraversalWeights(TraversalWeights);
+                return;
+        }
+
+        if (TraversalWeights.Num() != NumCells)
+        {
+                TraversalWeights.SetNum(NumCells);
+        }
+
+        const uint8 WeightValue = static_cast<uint8>(FMath::Clamp(DefaultTraversalWeight, 0, 255));
+        for (int32 Index = 0; Index < TraversalWeights.Num(); ++Index)
+        {
+                TraversalWeights[Index] = WeightValue;
+        }
+
+        FlowField.SetTraversalWeights(TraversalWeights);
+        bHasBuiltField = false;
+        bHasDebugSnapshot = false;
+}
+
+void AFlowFieldManager::RefreshDebugSnapshot()
+{
+        if (!bEnableDebugDraw)
+        {
+                bHasDebugSnapshot = false;
+                return;
+        }
+
+        DebugSnapshot = FlowField.CreateDebugSnapshot();
+        bHasDebugSnapshot = true;
+}
+
+void AFlowFieldManager::DrawDebug() const
+{
+        if (!bEnableDebugDraw)
+        {
+                return;
+        }
+
+        UWorld* World = GetWorld();
+        if (!World)
+        {
+                return;
+        }
+
+        const FIntPoint Size = bHasDebugSnapshot ? DebugSnapshot.GridSize : FlowFieldSettings.GridSize;
+        if (Size.X <= 0 || Size.Y <= 0)
+        {
+                return;
+        }
+
+        const float CellSizeLocal = bHasDebugSnapshot ? DebugSnapshot.CellSize : FlowFieldSettings.CellSize;
+        const FVector Origin = bHasDebugSnapshot ? DebugSnapshot.Origin : FlowFieldSettings.Origin;
+        const float ArrowLength = CellSizeLocal * DirectionArrowScale;
+        const FVector UpOffset(0.0f, 0.0f, DebugHeightOffset);
+
+        if (bDrawGrid)
+        {
+                const FVector Base = Origin + UpOffset;
+                for (int32 X = 0; X <= Size.X; ++X)
+                {
+                        const float OffsetX = static_cast<float>(X) * CellSizeLocal;
+                        const FVector Start = Base + FVector(OffsetX, 0.0f, 0.0f);
+                        const FVector End = Start + FVector(0.0f, Size.Y * CellSizeLocal, 0.0f);
+                        DrawDebugLine(World, Start, End, GridColor, false, 0.0f, 0, DebugLineThickness);
+                }
+
+                for (int32 Y = 0; Y <= Size.Y; ++Y)
+                {
+                        const float OffsetY = static_cast<float>(Y) * CellSizeLocal;
+                        const FVector Start = Base + FVector(0.0f, OffsetY, 0.0f);
+                        const FVector End = Start + FVector(Size.X * CellSizeLocal, 0.0f, 0.0f);
+                        DrawDebugLine(World, Start, End, GridColor, false, 0.0f, 0, DebugLineThickness);
+                }
+        }
+
+        if (!bHasDebugSnapshot)
+        {
+                return;
+        }
+
+        const int32 NumCells = Size.X * Size.Y;
+        for (int32 Index = 0; Index < NumCells; ++Index)
+        {
+                const int32 CellX = Index % Size.X;
+                const int32 CellY = Index / Size.X;
+
+                const FVector CellCenter = Origin + FVector((CellX + 0.5f) * CellSizeLocal, (CellY + 0.5f) * CellSizeLocal, 0.0f) + UpOffset;
+
+                const bool bIsWalkable = DebugSnapshot.WalkableField.IsValidIndex(Index) && DebugSnapshot.WalkableField[Index] > 0;
+
+                if (bDrawDirections)
+                {
+                        if (DebugSnapshot.DirectionField.IsValidIndex(Index))
+                        {
+                                const FVector Direction = FVector(DebugSnapshot.DirectionField[Index], 0.0f);
+                                if (!Direction.IsNearlyZero())
+                                {
+                                        const FVector Start = CellCenter;
+                                        const FVector End = Start + Direction.GetSafeNormal() * ArrowLength;
+                                        DrawDebugDirectionalArrow(World, Start, End, 25.0f, DirectionColor, false, 0.0f, 0, DebugLineThickness);
+                                }
+                        }
+                }
+
+                if (bDrawIntegrationValues)
+                {
+                        FString Label;
+                        if (bIsWalkable && DebugSnapshot.IntegrationField.IsValidIndex(Index))
+                        {
+                                const float Cost = DebugSnapshot.IntegrationField[Index];
+                                if (Cost < TNumericLimits<float>::Max())
+                                {
+                                        Label = FString::Printf(TEXT("%.1f"), Cost);
+                                }
+                                else
+                                {
+                                        Label = TEXT("∞");
+                                }
+                        }
+                        else
+                        {
+                                Label = TEXT("X");
+                        }
+
+                        const FColor TextColor = bIsWalkable ? IntegrationTextColor : BlockedCellColor;
+                        DrawDebugString(World, CellCenter, Label, nullptr, TextColor, 0.0f, true, DebugTextScale);
+                }
+                else if (bHighlightBlockedCells && !bIsWalkable)
+                {
+                        const FVector Extent(CellSizeLocal * 0.5f, CellSizeLocal * 0.5f, 10.0f);
+                        DrawDebugSolidBox(World, CellCenter, Extent, BlockedCellColor, false, 0.0f, 0);
+                }
+        }
+
+        if (bDrawDestination && bHasBuiltField)
+        {
+                const FVector DestinationLocation = CachedDestinationWorld + UpOffset;
+                DrawDebugSphere(World, DestinationLocation, DestinationMarkerRadius, 16, DirectionColor, false, 0.0f, 0, DebugLineThickness);
+        }
+}
+

--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.h
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.h
@@ -1,0 +1,168 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+
+#include "FlowField.h"
+
+#include "FlowFieldManager.generated.h"
+
+/**
+ * Centralised manager that owns a flow field and exposes debug utilities to visualise it in the level.
+ */
+UCLASS()
+class PLUGINSDEVELOPMENT_API AFlowFieldManager : public AActor
+{
+        GENERATED_BODY()
+
+public:
+        AFlowFieldManager();
+
+        virtual void Tick(float DeltaSeconds) override;
+        virtual void OnConstruction(const FTransform& Transform) override;
+        virtual void BeginPlay() override;
+
+        /** Rebuilds the flow field using the supplied destination cell. */
+        UFUNCTION(BlueprintCallable, Category = "Flow Field")
+        bool BuildFlowFieldToCell(const FIntPoint& DestinationCell);
+
+        /** Rebuilds the flow field using the supplied world destination. */
+        UFUNCTION(BlueprintCallable, Category = "Flow Field")
+        bool BuildFlowFieldToWorldLocation(const FVector& DestinationLocation);
+
+        /** Samples the flow direction for a given world position. */
+        UFUNCTION(BlueprintCallable, Category = "Flow Field")
+        FVector GetDirectionForWorldPosition(const FVector& WorldPosition) const;
+
+        /** Returns the current flow field settings. */
+        const FFlowFieldSettings& GetSettings() const { return FlowFieldSettings; }
+
+        /** Converts a world position into a cell coordinate using the managed flow field. */
+        FIntPoint WorldToCell(const FVector& WorldPosition) const { return FlowField.WorldToCell(WorldPosition); }
+
+        /** Converts a cell coordinate into a world position using the managed flow field. */
+        FVector CellToWorld(const FIntPoint& Cell) const { return FlowField.CellToWorld(Cell); }
+
+        /** Returns true if the supplied cell is walkable within the current traversal weights. */
+        bool IsWalkable(const FIntPoint& Cell) const { return FlowField.IsWalkable(Cell); }
+
+        /** Returns true if the manager currently has a valid built field. */
+        bool HasValidField() const { return bHasBuiltField; }
+
+protected:
+        void UpdateFlowFieldSettings();
+        void UpdateTraversalWeights();
+        void RefreshDebugSnapshot();
+        void DrawDebug() const;
+
+private:
+        /** Size of the flow field grid. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        FIntPoint GridSize = FIntPoint(32, 32);
+
+        /** Size of each cell in world units. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "1"))
+        float CellSize = 200.0f;
+
+        /** Whether diagonal movement is allowed when generating the flow field. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        bool bAllowDiagonal = true;
+
+        /** Cost multiplier for diagonal movement. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0.0"))
+        float DiagonalCostMultiplier = 1.41421356f;
+
+        /** Base traversal cost for every step. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0.0"))
+        float StepCost = 1.0f;
+
+        /** Traversal weight multiplier applied to each cell. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0.0"))
+        float CellTraversalWeightMultiplier = 1.0f;
+
+        /** Additional heuristic weight applied when evaluating neighbours. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0.0"))
+        float HeuristicWeight = 1.0f;
+
+        /** Whether the field should smooth the resulting directions. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        bool bSmoothDirections = true;
+
+        /** Optional offset applied after centering the grid around the actor location. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        FVector AdditionalOriginOffset = FVector::ZeroVector;
+
+        /** Default traversal weight assigned to each cell. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0", ClampMax = "255"))
+        int32 DefaultTraversalWeight = 255;
+
+        /** Height offset applied when drawing debug information. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        float DebugHeightOffset = 50.0f;
+
+        /** Enables debug visualisation of the flow field. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        bool bEnableDebugDraw = true;
+
+        /** Draws the grid bounds when debug draw is enabled. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (EditCondition = "bEnableDebugDraw"))
+        bool bDrawGrid = true;
+
+        /** Draws direction arrows for each cell. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (EditCondition = "bEnableDebugDraw"))
+        bool bDrawDirections = true;
+
+        /** Draws integration costs for each cell. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (EditCondition = "bEnableDebugDraw"))
+        bool bDrawIntegrationValues = false;
+
+        /** Draws blocked cells with a dedicated colour. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (EditCondition = "bEnableDebugDraw"))
+        bool bHighlightBlockedCells = true;
+
+        /** Draws the current destination location. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (EditCondition = "bEnableDebugDraw"))
+        bool bDrawDestination = true;
+
+        /** Colour used when drawing flow directions. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        FColor DirectionColor = FColor::Green;
+
+        /** Colour used when drawing integration cost text. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        FColor IntegrationTextColor = FColor::White;
+
+        /** Colour used to highlight blocked cells. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        FColor BlockedCellColor = FColor::Red;
+
+        /** Colour used to draw the grid lines. */
+        UPROPERTY(EditAnywhere, Category = "Debug")
+        FColor GridColor = FColor::Cyan;
+
+        /** Thickness applied when drawing debug lines. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (ClampMin = "0.0"))
+        float DebugLineThickness = 2.0f;
+
+        /** Length of the direction arrows relative to the cell size. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (ClampMin = "0.0"))
+        float DirectionArrowScale = 0.4f;
+
+        /** Scale applied to debug text. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (ClampMin = "0.1"))
+        float DebugTextScale = 1.0f;
+
+        /** Radius used when drawing the destination marker. */
+        UPROPERTY(EditAnywhere, Category = "Debug", meta = (ClampMin = "0.0"))
+        float DestinationMarkerRadius = 75.0f;
+
+private:
+        FFlowField FlowField;
+        FFlowFieldSettings FlowFieldSettings;
+        TArray<uint8> TraversalWeights;
+        FFlowFieldDebugSnapshot DebugSnapshot;
+        bool bHasBuiltField = false;
+        bool bHasDebugSnapshot = false;
+        FVector CachedDestinationWorld = FVector::ZeroVector;
+};
+

--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.h
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldTestActor.h
@@ -3,9 +3,9 @@
 #include "CoreMinimal.h"
 #include "GameFramework/Actor.h"
 
-#include "FlowField.h"
-
 #include "FlowFieldTestActor.generated.h"
+
+class AFlowFieldManager;
 
 /**
  * Simple actor that roams around by following a flow field towards random destinations.
@@ -25,51 +25,27 @@ protected:
 	virtual void BeginPlay() override;
 
 private:
-	/** Rebuilds the flow field settings and traversal weights around the actor. */
-	void UpdateFlowFieldSettings();
+        /** Picks a new destination around the actor and rebuilds the flow field towards it. */
+        bool TryAssignNewDestination();
 
-	/** Picks a new destination around the actor and rebuilds the flow field towards it. */
-	bool TryAssignNewDestination();
+        /** Returns true if the actor reached the current destination. */
+        bool HasReachedDestination() const;
 
-	/** Returns true if the actor reached the current destination. */
-	bool HasReachedDestination() const;
+        /** Attempts to find a flow field manager in the current world. */
+        AFlowFieldManager* ResolveFlowFieldManager();
 
 private:
-	/** Size of the flow field grid. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	FIntPoint GridSize = FIntPoint(32, 32);
+        /** Flow field manager that will be used to drive this actor. */
+        UPROPERTY(EditInstanceOnly, Category = "Flow Field")
+        AFlowFieldManager* FlowFieldManager = nullptr;
 
-	/** Size of each flow field cell in world units. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float CellSize = 200.0f;
+        /** Whether the actor should automatically look for a manager if none is assigned. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        bool bAutoFindManager = true;
 
-	/** Whether diagonal movement is allowed when generating the flow field. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	bool bAllowDiagonal = true;
-
-	/** Cost multiplier for diagonal movement. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float DiagonalCostMultiplier = 1.41421356f;
-
-	/** Base traversal cost for every step. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float StepCost = 1.0f;
-
-	/** Traversal weight multiplier applied to each cell. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float CellTraversalWeightMultiplier = 1.0f;
-
-	/** Additional heuristic weight applied when evaluating neighbours. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float HeuristicWeight = 1.0f;
-
-	/** Whether the field should smooth the resulting directions. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	bool bSmoothDirections = true;
-
-	/** Search radius (in world units) used when picking a new random destination. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	float DestinationSearchRadius = 2000.0f;
+        /** Search radius (in world units) used when picking a new random destination. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        float DestinationSearchRadius = 2000.0f;
 
 	/** Distance threshold used to consider the destination reached. */
 	UPROPERTY(EditAnywhere, Category = "Flow Field")
@@ -80,14 +56,10 @@ private:
 	float MovementSpeed = 600.0f;
 
 	/** Maximum number of attempts when searching for a new destination. */
-	UPROPERTY(EditAnywhere, Category = "Flow Field")
-	int32 MaxDestinationAttempts = 24;
+        UPROPERTY(EditAnywhere, Category = "Flow Field")
+        int32 MaxDestinationAttempts = 24;
 
 private:
-	FFlowField FlowField;
-	FFlowFieldSettings FlowFieldSettings;
-	TArray<uint8> TraversalWeights;
-	FVector CurrentDestination = FVector::ZeroVector;
-	FVector AnchorLocation = FVector::ZeroVector;
-	bool bHasDestination = false;
+        FVector CurrentDestination = FVector::ZeroVector;
+        bool bHasDestination = false;
 };


### PR DESCRIPTION
## Summary
- add a dedicated FlowFieldManager actor that owns the flow field, exposes build helpers, and renders extensive debug information
- rework the FlowFieldTestActor to resolve a manager in the level and drive its movement using the shared flow field

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dba6b5c2888330aaea2aad2d79232a