### PR TITLE
Add slope-aware traversal weights for flow field manager

### DIFF
--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.cpp
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.cpp
@@ -141,7 +141,19 @@ void AFlowFieldManager::UpdateTraversalWeights()
 
                         FHitResult Hit;
                         const bool bHit = World->LineTraceSingleByChannel(Hit, TraceStart, TraceEnd, TerrainCollisionChannel, QueryParams);
-                        TraversalWeights[Index] = bHit ? WeightValue : 0;
+                        if (bHit)
+                        {
+                                const FVector HitNormal = Hit.ImpactNormal.GetSafeNormal();
+                                const float Dot = FVector::DotProduct(HitNormal, FVector::UpVector);
+                                const float ClampedDot = FMath::Clamp(Dot, -1.0f, 1.0f);
+                                const float SlopeAngleDegrees = FMath::RadiansToDegrees(FMath::Acos(ClampedDot));
+                                const bool bWithinSlopeLimit = SlopeAngleDegrees <= MaxWalkableSlopeAngle;
+                                TraversalWeights[Index] = bWithinSlopeLimit ? WeightValue : 0;
+                        }
+                        else
+                        {
+                                TraversalWeights[Index] = 0;
+                        }
                 }
         }
         else

--- a/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.h
+++ b/Source/PluginsDevelopment/Pathfinding/FlowFieldManager.h
@@ -82,6 +82,10 @@ private:
         UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (EditCondition = "bAutoSizeToTerrain"))
         TEnumAsByte<ECollisionChannel> TerrainCollisionChannel = ECC_WorldStatic;
 
+        /** Maximum slope angle (in degrees) that is considered walkable. */
+        UPROPERTY(EditAnywhere, Category = "Flow Field", meta = (ClampMin = "0.0", ClampMax = "90.0"))
+        float MaxWalkableSlopeAngle = 45.0f;
+
         /** Size of the flow field grid. */
         UPROPERTY(EditAnywhere, Category = "Flow Field")
         FIntPoint GridSize = FIntPoint(32, 32);


### PR DESCRIPTION
## Summary
- add an editable maximum walkable slope angle to the flow field manager
- filter traversal weights based on the detected surface normal to prevent routing across steep walls or slopes

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dbf9ac66008330b12279c8d6c1cf74